### PR TITLE
fix: no declaration for TuyauProvider

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -106,7 +106,7 @@
     "@radix-ui/react-tooltip": "^1.1.5",
     "@tuyau/client": "^0.2.2",
     "@tuyau/core": "^0.2.3",
-    "@tuyau/inertia": "^0.0.8",
+    "@tuyau/inertia": "^0.0.7",
     "@vinejs/vine": "^3.0.0",
     "better-sqlite3": "^11.7.0",
     "class-variance-authority": "^0.7.1",

--- a/website/package.json
+++ b/website/package.json
@@ -107,6 +107,7 @@
     "@tuyau/client": "^0.2.2",
     "@tuyau/core": "^0.2.3",
     "@tuyau/inertia": "^0.0.7",
+    "@tuyau/utils": "^0.0.6",
     "@vinejs/vine": "^3.0.0",
     "better-sqlite3": "^11.7.0",
     "class-variance-authority": "^0.7.1",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       '@tuyau/inertia':
         specifier: ^0.0.7
         version: 0.0.7(@inertiajs/react@2.0.0(react@19.0.0))(@tuyau/client@0.2.2)(react@19.0.0)
+      '@tuyau/utils':
+        specifier: ^0.0.6
+        version: 0.0.6
       '@vinejs/vine':
         specifier: ^3.0.0
         version: 3.0.0

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -141,8 +141,8 @@ importers:
         specifier: ^0.2.3
         version: 0.2.3(@adonisjs/core@6.17.0(@adonisjs/assembler@7.8.2(typescript@5.7.2))(@vinejs/vine@3.0.0)(edge.js@6.2.0))
       '@tuyau/inertia':
-        specifier: ^0.0.8
-        version: 0.0.8(@inertiajs/react@2.0.0(react@19.0.0))(@tuyau/client@0.2.2)(react@19.0.0)
+        specifier: ^0.0.7
+        version: 0.0.7(@inertiajs/react@2.0.0(react@19.0.0))(@tuyau/client@0.2.2)(react@19.0.0)
       '@vinejs/vine':
         specifier: ^3.0.0
         version: 3.0.0
@@ -2274,14 +2274,14 @@ packages:
     peerDependencies:
       '@adonisjs/core': ^6.2.0
 
-  '@tuyau/inertia@0.0.8':
-    resolution: {integrity: sha512-KAGx8s7CjruYkU1tJIS0Iq52IyM9zt/H/CweuLEN7Xtihs2xs47yy70+61NcHcuYJlCAGZzWVSL7FC2iK0HZVA==}
+  '@tuyau/inertia@0.0.7':
+    resolution: {integrity: sha512-zY4DD50hxn/U8ciMmE0uNjB3wigo1Z4llvyNVCyzpnVMBunwTSEOjIzvxUwhstC/5eKO1DyiSrk04ncJZKREpg==}
     peerDependencies:
-      '@inertiajs/react': ^1.0.0 || ^2.0.0
-      '@inertiajs/vue3': ^1.0.0 || ^2.0.0
+      '@inertiajs/react': ^1.0.16
+      '@inertiajs/vue3': ^1.0.16
       '@tuyau/client': 0.2.2
-      react: ^18.0.0 || ^19.0.0
-      vue: ^3.0.0
+      react: ^18.3.1
+      vue: ^3.4.27
     peerDependenciesMeta:
       '@inertiajs/react':
         optional: true
@@ -8509,7 +8509,7 @@ snapshots:
       '@tuyau/utils': 0.0.6
       ts-morph: 23.0.0
 
-  '@tuyau/inertia@0.0.8(@inertiajs/react@2.0.0(react@19.0.0))(@tuyau/client@0.2.2)(react@19.0.0)':
+  '@tuyau/inertia@0.0.7(@inertiajs/react@2.0.0(react@19.0.0))(@tuyau/client@0.2.2)(react@19.0.0)':
     dependencies:
       '@tuyau/client': 0.2.2
     optionalDependencies:


### PR DESCRIPTION
For some reason, in v0.0.8, @tuyau/inertia stopped shipping .d.ts files.

Check `build` folder in https://www.npmjs.com/package/@tuyau/inertia/v/0.0.7?activeTab=code vs https://www.npmjs.com/package/@tuyau/inertia/v/0.0.8?activeTab=code.