### PR TITLE
fix: hot reload crash in homepage

### DIFF
--- a/website/inertia/lib/countdown.ts
+++ b/website/inertia/lib/countdown.ts
@@ -63,7 +63,5 @@ export function createCountdown({
   // tick once so listeners are up-to-date
   tick()
 
-  return {
-    abort: controller.abort,
-  }
+  return { abort: AbortController.prototype.abort.bind(controller) }
 }


### PR DESCRIPTION
When changing code and the homepage would hot reload, the page would be blank after the reload. This is because AbortController is a class and, as such, if a method from it is destructured, the method also needs to be bound to the instance of the class. 