### PR TITLE
Feature/speaker and company profiles

### DIFF
--- a/website/app/admin/resources/speaker_profile_resource.ts
+++ b/website/app/admin/resources/speaker_profile_resource.ts
@@ -1,0 +1,16 @@
+import dbConfig from "#config/database"
+import SpeakerProfile from "#models/speaker_profile"
+import { LucidResource } from "@adminjs/adonis"
+
+const SpeakerProfileResource = {
+  resource: new LucidResource(SpeakerProfile, dbConfig.connection),
+  options: {
+    properties: {
+      company_id: {
+        isVisible: { list: true, filter: true, show: true, edit: true },
+      },
+    },
+  }
+}
+
+export default SpeakerProfileResource

--- a/website/app/controllers/profiles_controller.ts
+++ b/website/app/controllers/profiles_controller.ts
@@ -1,5 +1,5 @@
 import ParticipantProfile from '#models/participant_profile'
-import { createProfileValidator } from '#validators/profile'
+import { createProfileValidator, updateProfileValidator } from '#validators/profile'
 import type { HttpContext } from '@adonisjs/core/http'
 import slug from 'slug';
 import Sqids from 'sqids'
@@ -7,6 +7,26 @@ import Sqids from 'sqids'
 const sludSqids = new Sqids({
   alphabet: 'nkzm6vl3170gtx8uro9aj4iyqhwdpcebsf52' // lowercase letters and numbers
 })
+
+function toParticipantProfileFormat(data: any): Partial<ParticipantProfile> {
+  if ('curricularYear' in data) {
+    data.finishedAt = data.curricularYear[1]
+    data.curricularYear = data.curricularYear[0]
+  }
+  // HACK
+  if ('transports' in data)
+    data.transports = data.transports
+      .map((item: { label: string; value: string; }) => item.value)
+  if ('attendedBeforeEditions' in data)
+    data.attendedBeforeEditions = data.attendedBeforeEditions
+      .map((item: { label: string; value: string; }) => item.value)
+  if ('dietaryRestrictions' in data)
+    data.dietaryRestrictions ||= ""
+  if ('reasonForSignup' in data)
+    data.reasonForSignup ||= ""
+
+  return data
+}
 
 export default class ProfilesController {
   async default({ auth, response }: HttpContext) {
@@ -16,7 +36,7 @@ export default class ProfilesController {
     if (!user?.participantProfile)
       return response.redirect().toRoute('pages:signup')
 
-    return response.redirect().toRoute('pages:profile.show', { slug: user.participantProfile.slug } )
+    return response.redirect().toRoute('pages:profile.show', { slug: user.participantProfile.slug })
   }
 
   async index({ auth, inertia, params, response }: HttpContext) {
@@ -48,6 +68,19 @@ export default class ProfilesController {
     return inertia.render('profile/edit', { profile: user!.participantProfile! })
   }
 
+  async update({ auth, request, response }: HttpContext) {
+    const user = auth.getUserOrFail()
+    const data = request.body()
+
+    await user!.load('participantProfile')
+
+    const newFields = await updateProfileValidator.validate(toParticipantProfileFormat(data))
+
+    await user.participantProfile.merge(newFields).save()
+
+    return response.redirect().toRoute('pages:profile.default')
+  }
+
   async show({ inertia }: HttpContext) {
     return inertia.render('signup')
   }
@@ -56,19 +89,11 @@ export default class ProfilesController {
     const user = auth.getUserOrFail()
 
     const data = request.body()
-    data.finishedAt = data.curricularYear[1]
-    data.curricularYear = data.curricularYear[0]
-    // HACK
-    data.transports = data.transports
-      .map((item: { label: string; value: string; }) => item.value)
-    data.attendedBeforeEditions = data.attendedBeforeEditions
-      .map((item: { label: string; value: string; }) => item.value)
-    data.dietaryRestrictions ||= ""
-    data.reasonForSignup ||= ""
 
-    data.slug = slug(`${data.firstName} ${data.lastName} ${sludSqids.encode([user.id])}`)
+    const formattedData = toParticipantProfileFormat(data)
+    formattedData.slug = slug(`${formattedData.firstName} ${formattedData.lastName} ${sludSqids.encode([user.id])}`)
 
-    const profile = await createProfileValidator.validate(data)
+    const profile = await createProfileValidator.validate(formattedData)
 
     const profileAdd = new ParticipantProfile()
     profileAdd.fill(profile)
@@ -77,5 +102,5 @@ export default class ProfilesController {
 
     return response.redirect().toRoute('pages:profile.default')
   }
-  
+
 }

--- a/website/app/controllers/profiles_controller.ts
+++ b/website/app/controllers/profiles_controller.ts
@@ -1,4 +1,5 @@
 import ParticipantProfile from '#models/participant_profile'
+import User from '#models/user';
 import { createProfileValidator, updateProfileValidator } from '#validators/profile'
 import type { HttpContext } from '@adonisjs/core/http'
 import slug from 'slug';
@@ -32,60 +33,36 @@ export default class ProfilesController {
   async default({ auth, response }: HttpContext) {
     const user = auth.user;
 
-    switch(user?.role) {
-      case "company":
-        await user!.load('companyProfile')
-
-        if (!user?.companyProfile)
-          return response.redirect().toRoute('pages:signup')
-        break;
-      case "participant":
-        await user!.load('participantProfile')
-
-        if (!user?.participantProfile)
-          return response.redirect().toRoute('pages:signup')
-        break;
-      case "promoter":
-        await user!.load('promoterProfile')
-
-        if (!user?.promoterProfile)
-          return response.redirect().toRoute('pages:signup')
-        break;
-      case "representative":
-        await user!.load('representativeProfile')
-
-        if (!user?.representativeProfile)
-          return response.redirect().toRoute('pages:signup')
-        break;
-      case "speaker":
-        await user!.load('speakerProfile')
-
-        if (!user?.speakerProfile)
-          return response.redirect().toRoute('pages:signup')
-        break;
-      case "unknown":
-        response.notFound("Perfil não encontrado")
-        break;
+    if (!user) {
+      response.notFound("Utilizador não encontrado")
+      return
     }
 
-    return response.redirect().toRoute('pages:profile.show', { slug: user?.participantProfile.slug })
+    const profile = User.getProfile(user)
+
+    if (!profile)
+      return response.redirect().toRoute('pages:signup')
+
+    console.log(user.slug)
+    return response.redirect().toRoute('pages:profile.show', { slug: user.slug })
   }
 
   async index({ auth, inertia, params, response }: HttpContext) {
-    const profile = await ParticipantProfile.findBy('slug', params.slug)
+    const user = await User.findBy('slug', params.slug)
+
+    if (!user) {
+      response.notFound("Participante não encontrado")
+      return
+    }
+
+    const profile = await User.getProfile(user)
 
     if (!profile) {
-      response.notFound("Participante não encontrado")
+      response.notFound("Perfil não encontrado")
       return
     }
 
-    await profile.load('user')
-    if (!profile.user) {
-      response.notFound("Participante não encontrado")
-      return
-    }
-
-    const isUser = profile.user ? (profile.user.id === auth.user?.id) : false;
+    const isUser = user ? (user.id === auth.user?.id) : false;
 
     return inertia.render('profile', { profile, isUser })
   }
@@ -123,9 +100,9 @@ export default class ProfilesController {
     const data = request.body()
 
     const formattedData = toParticipantProfileFormat(data)
-    formattedData.slug = slug(`${formattedData.firstName} ${formattedData.lastName} ${sludSqids.encode([user.id])}`)
 
     const profile = await createProfileValidator.validate(formattedData)
+    user.slug = slug(`${formattedData.firstName} ${formattedData.lastName} ${sludSqids.encode([user.id])}`)
 
     const profileAdd = new ParticipantProfile()
     profileAdd.fill(profile)

--- a/website/app/controllers/profiles_controller.ts
+++ b/website/app/controllers/profiles_controller.ts
@@ -31,12 +31,44 @@ function toParticipantProfileFormat(data: any): Partial<ParticipantProfile> {
 export default class ProfilesController {
   async default({ auth, response }: HttpContext) {
     const user = auth.user;
-    await user!.load('participantProfile')
 
-    if (!user?.participantProfile)
-      return response.redirect().toRoute('pages:signup')
+    switch(user?.role) {
+      case "company":
+        await user!.load('companyProfile')
 
-    return response.redirect().toRoute('pages:profile.show', { slug: user.participantProfile.slug })
+        if (!user?.companyProfile)
+          return response.redirect().toRoute('pages:signup')
+        break;
+      case "participant":
+        await user!.load('participantProfile')
+
+        if (!user?.participantProfile)
+          return response.redirect().toRoute('pages:signup')
+        break;
+      case "promoter":
+        await user!.load('promoterProfile')
+
+        if (!user?.promoterProfile)
+          return response.redirect().toRoute('pages:signup')
+        break;
+      case "representative":
+        await user!.load('representativeProfile')
+
+        if (!user?.representativeProfile)
+          return response.redirect().toRoute('pages:signup')
+        break;
+      case "speaker":
+        await user!.load('speakerProfile')
+
+        if (!user?.speakerProfile)
+          return response.redirect().toRoute('pages:signup')
+        break;
+      case "unknown":
+        response.notFound("Perfil não encontrado")
+        break;
+    }
+
+    return response.redirect().toRoute('pages:profile.show', { slug: user?.participantProfile.slug })
   }
 
   async index({ auth, inertia, params, response }: HttpContext) {

--- a/website/app/controllers/profiles_controller.ts
+++ b/website/app/controllers/profiles_controller.ts
@@ -1,4 +1,6 @@
+import Company from '#models/company';
 import ParticipantProfile from '#models/participant_profile'
+import SpeakerProfile from '#models/speaker_profile';
 import User from '#models/user';
 import { createProfileValidator, updateProfileValidator } from '#validators/profile'
 import type { HttpContext } from '@adonisjs/core/http'
@@ -60,6 +62,10 @@ export default class ProfilesController {
     if (!profile) {
       response.notFound("Perfil não encontrado")
       return
+    }
+
+    if (profile instanceof SpeakerProfile) {
+      profile.loadOnce('company')
     }
 
     const isUser = user ? (user.id === auth.user?.id) : false;

--- a/website/app/controllers/profiles_controller.ts
+++ b/website/app/controllers/profiles_controller.ts
@@ -1,4 +1,3 @@
-import Company from '#models/company';
 import ParticipantProfile from '#models/participant_profile'
 import SpeakerProfile from '#models/speaker_profile';
 import User from '#models/user';

--- a/website/app/models/company.ts
+++ b/website/app/models/company.ts
@@ -4,6 +4,8 @@ import type { HasOne } from '@adonisjs/lucid/types/relations'
 import User from './user.js'
 
 export default class Company extends BaseModel {
+  public static table = 'company_profiles'
+
   @column({ isPrimary: true })
   declare id: number
   

--- a/website/app/models/company.ts
+++ b/website/app/models/company.ts
@@ -3,7 +3,7 @@ import { BaseModel, column, hasOne } from '@adonisjs/lucid/orm'
 import type { HasOne } from '@adonisjs/lucid/types/relations'
 import User from './user.js'
 
-export default class CompanyProfile extends BaseModel {
+export default class Company extends BaseModel {
   @column({ isPrimary: true })
   declare id: number
   

--- a/website/app/models/company_profile.ts
+++ b/website/app/models/company_profile.ts
@@ -1,0 +1,24 @@
+import { DateTime } from 'luxon'
+import { BaseModel, column, hasOne } from '@adonisjs/lucid/orm'
+import type { HasOne } from '@adonisjs/lucid/types/relations'
+import User from './user.js'
+
+export default class CompanyProfile extends BaseModel {
+  @column({ isPrimary: true })
+  declare id: number
+  
+  @hasOne(() => User)
+  declare user: HasOne<typeof User>
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+  
+  @column()
+  declare name: string
+
+  @column()
+  declare logo: string
+}

--- a/website/app/models/participant_profile.ts
+++ b/website/app/models/participant_profile.ts
@@ -83,7 +83,7 @@ export default class ParticipantProfile extends BaseModel {
   // Profile Info
 
   @column()
-  declare slug: string | null
+  declare slug: string
 
   @column()
   declare about: string | null

--- a/website/app/models/participant_profile.ts
+++ b/website/app/models/participant_profile.ts
@@ -81,10 +81,6 @@ export default class ParticipantProfile extends BaseModel {
   declare attendedBeforeEditions: string[]
 
   // Profile Info
-
-  @column()
-  declare slug: string
-
   @column()
   declare about: string | null
 

--- a/website/app/models/representative_profile.ts
+++ b/website/app/models/representative_profile.ts
@@ -5,7 +5,7 @@ import User from './user.js'
 // import Event from './event.js'
 import Company from './company.js'
 
-export default class SpeakerProfile extends BaseModel {
+export default class RepresentativeProfile extends BaseModel {
   @column({ isPrimary: true })
   declare id: number
 

--- a/website/app/models/representative_profile.ts
+++ b/website/app/models/representative_profile.ts
@@ -18,7 +18,7 @@ export default class SpeakerProfile extends BaseModel {
   @column.dateTime({ autoCreate: true, autoUpdate: true })
   declare updatedAt: DateTime
 
-  // Speaker Info
+  // Representative Info
 
   @column()
   declare firstName: string
@@ -38,4 +38,9 @@ export default class SpeakerProfile extends BaseModel {
   // To uncomment when Events are created
   // @hasMany(() => Event)
   // declare participatingEvents: HasMany<typeof Event>
+
+  // Functions
+  static async getCompanyRepresentatives(companyId: number) {
+    return this.query().where('company_id', companyId)
+  }
 }

--- a/website/app/models/speaker_profile.ts
+++ b/website/app/models/speaker_profile.ts
@@ -6,6 +6,8 @@ import User from './user.js'
 import Company from './company.js'
 
 export default class SpeakerProfile extends BaseModel {
+  public static table = 'speaker_profiles'
+
   @column({ isPrimary: true })
   declare id: number
 
@@ -34,6 +36,12 @@ export default class SpeakerProfile extends BaseModel {
 
   @column()
   declare ORCIDLink: string | null
+
+  @column()
+  declare companyId: number | null
+
+  @column()
+  declare about: string | null
 
   @belongsTo(() => Company)
   declare company: BelongsTo<typeof Company>

--- a/website/app/models/speaker_profile.ts
+++ b/website/app/models/speaker_profile.ts
@@ -30,6 +30,9 @@ export default class SpeakerProfile extends BaseModel {
   declare jobTitle: string
 
   @column()
+  declare speakerRole: "keynote_speaker" | "panelist" | "moderator"
+
+  @column()
   declare ORCIDLink: string | null
 
   @belongsTo(() => Company)

--- a/website/app/models/speaker_profile.ts
+++ b/website/app/models/speaker_profile.ts
@@ -1,0 +1,41 @@
+import { DateTime } from 'luxon'
+import { BaseModel, column, hasOne } from '@adonisjs/lucid/orm'
+import type { HasOne } from '@adonisjs/lucid/types/relations'
+import User from './user.js'
+// import Event from './event.js'
+import CompanyProfile from './company_profile.js'
+
+export default class SpeakerProfile extends BaseModel {
+  @column({ isPrimary: true })
+  declare id: number
+
+  @hasOne(() => User)
+  declare user: HasOne<typeof User>
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+
+  // Speaker Info
+
+  @column()
+  declare firstName: string
+
+  @column()
+  declare lastName: string
+
+  @column()
+  declare jobTitle: string
+
+  @column()
+  declare ORCIDLink: string | null
+
+  @hasOne(() => CompanyProfile)
+  declare company: HasOne<typeof CompanyProfile>
+
+  // To uncomment when Events are created
+  // @hasMany(() => Event)
+  // declare participatingEvents: HasMany<typeof Event>
+}

--- a/website/app/models/user.ts
+++ b/website/app/models/user.ts
@@ -6,6 +6,7 @@ import PromoterInfo from './promoter_info.js'
 import type { BelongsTo, HasMany } from '@adonisjs/lucid/types/relations'
 import PromoterProfile from './promoter_profile.js'
 import ParticipantProfile from './participant_profile.js'
+import CompanyProfile from './company_profile.js'
 
 export default class User extends BaseModel {
   @column({ isPrimary: true })
@@ -68,6 +69,22 @@ export default class User extends BaseModel {
 
   @belongsTo(() => PromoterInfo)
   declare promoterInfo: BelongsTo<typeof PromoterInfo>
+
+  // CompanyProfile
+
+  @column()
+  declare companyProfileId: number | undefined
+
+  @belongsTo(() => CompanyProfile)
+  declare companyProfile: BelongsTo<typeof CompanyProfile>
+
+  // SpeakerProfile
+
+  @column()
+  declare speakerProfileId: number | undefined
+
+  @belongsTo(() => CompanyProfile)
+  declare speakerProfile: BelongsTo<typeof CompanyProfile>
 
   // Functions
 

--- a/website/app/models/user.ts
+++ b/website/app/models/user.ts
@@ -32,6 +32,9 @@ export default class User extends BaseModel {
   @hasMany(() => Account)
   declare accounts: HasMany<typeof Account>
 
+  @column()
+  declare slug: string | null
+
   // Referrals
 
   @column()

--- a/website/app/models/user.ts
+++ b/website/app/models/user.ts
@@ -7,6 +7,8 @@ import type { BelongsTo, HasMany } from '@adonisjs/lucid/types/relations'
 import PromoterProfile from './promoter_profile.js'
 import ParticipantProfile from './participant_profile.js'
 import CompanyProfile from './company.js'
+import SpeakerProfile from './speaker_profile.js'
+import RepresentativeProfile from './representative_profile.js'
 
 export default class User extends BaseModel {
   @column({ isPrimary: true })
@@ -83,14 +85,25 @@ export default class User extends BaseModel {
   @column()
   declare speakerProfileId: number | undefined
 
-  @belongsTo(() => CompanyProfile)
-  declare speakerProfile: BelongsTo<typeof CompanyProfile>
+  @belongsTo(() => SpeakerProfile)
+  declare speakerProfile: BelongsTo<typeof SpeakerProfile>
+
+  // RepresentantiveProfile
+
+  @column()
+  declare representativeProfileId: number | undefined
+
+  @belongsTo(() => RepresentativeProfile)
+  declare representativeProfile: BelongsTo<typeof RepresentativeProfile>
 
   // Functions
 
   get role() {
     if (this.isParticipant()) return 'participant' as const
     if (this.isPromoter()) return 'promoter' as const
+    if (this.isSpeaker()) return 'speaker' as const
+    if (this.isCompany()) return 'company' as const
+    if (this.isRepresentative()) return 'representative' as const
     return 'unknown' as const
   }
 
@@ -102,6 +115,18 @@ export default class User extends BaseModel {
     return this.participantProfileId
   }
 
+  isSpeaker() {
+    return this.speakerProfileId
+  }
+
+  isCompany() {
+    return this.companyProfileId
+  }
+
+  isRepresentative() {
+    return this.representativeProfileId
+  }
+  
   isEmailVerified() {
     return this.emailVerifiedAt !== null
   }

--- a/website/app/models/user.ts
+++ b/website/app/models/user.ts
@@ -6,7 +6,7 @@ import PromoterInfo from './promoter_info.js'
 import type { BelongsTo, HasMany } from '@adonisjs/lucid/types/relations'
 import PromoterProfile from './promoter_profile.js'
 import ParticipantProfile from './participant_profile.js'
-import CompanyProfile from './company_profile.js'
+import CompanyProfile from './company.js'
 
 export default class User extends BaseModel {
   @column({ isPrimary: true })

--- a/website/app/models/user.ts
+++ b/website/app/models/user.ts
@@ -56,7 +56,7 @@ export default class User extends BaseModel {
   // PromoterProfile
 
   @column()
-  declare promoterProfileId: number | undefined
+  declare promoterProfileId: number | null
 
   @belongsTo(() => PromoterProfile)
   declare promoterProfile: BelongsTo<typeof PromoterProfile>
@@ -64,7 +64,7 @@ export default class User extends BaseModel {
   // ParticipantProfile
 
   @column()
-  declare participantProfileId: number | undefined
+  declare participantProfileId: number | null
 
   @belongsTo(() => ParticipantProfile)
   declare participantProfile: BelongsTo<typeof ParticipantProfile>
@@ -78,7 +78,7 @@ export default class User extends BaseModel {
   // CompanyProfile
 
   @column()
-  declare companyProfileId: number | undefined
+  declare companyId: number | null
 
   @belongsTo(() => CompanyProfile)
   declare companyProfile: BelongsTo<typeof CompanyProfile>
@@ -86,7 +86,7 @@ export default class User extends BaseModel {
   // SpeakerProfile
 
   @column()
-  declare speakerProfileId: number | undefined
+  declare speakerProfileId: number | null
 
   @belongsTo(() => SpeakerProfile)
   declare speakerProfile: BelongsTo<typeof SpeakerProfile>
@@ -94,7 +94,7 @@ export default class User extends BaseModel {
   // RepresentantiveProfile
 
   @column()
-  declare representativeProfileId: number | undefined
+  declare representativeProfileId: number | null
 
   @belongsTo(() => RepresentativeProfile)
   declare representativeProfile: BelongsTo<typeof RepresentativeProfile>
@@ -114,7 +114,7 @@ export default class User extends BaseModel {
     return this.promoterProfileId
   }
 
-  isParticipant() {
+  isParticipant() {null
     return this.participantProfileId
   }
 
@@ -123,7 +123,7 @@ export default class User extends BaseModel {
   }
 
   isCompany() {
-    return this.companyProfileId
+    return this.companyId
   }
 
   isRepresentative() {
@@ -147,6 +147,28 @@ export default class User extends BaseModel {
   wasReferred() {
     return !this.referrerId
   }
+
+  static async getProfile(user: User): Promise<ParticipantProfile | PromoterProfile | SpeakerProfile | CompanyProfile | RepresentativeProfile | null> {
+    switch (user.role) {
+      case 'participant':
+        await user.loadOnce('participantProfile')
+        return user.participantProfile
+      case 'promoter':
+        await user.loadOnce('promoterProfile')
+        return user.promoterProfile
+      case 'speaker':
+        await user.loadOnce('speakerProfile')
+        return user.speakerProfile
+      case 'company':
+        await user.loadOnce('companyProfile')
+        return user.companyProfile
+      case 'representative':
+        await user.loadOnce('representativeProfile')
+        return user.representativeProfile
+      default:
+        return null
+    }
+  }  
 
   static async hasPurchasedTicket(user: User) {
     if (!user.isParticipant()) return false

--- a/website/app/validators/profile.ts
+++ b/website/app/validators/profile.ts
@@ -33,3 +33,35 @@ export const createProfileValidator = vine.compile(
     attendedBeforeEditions: vine.array(vine.string().in(editions.map((item) => item.year.toString()))),
   })
 )
+
+export const updateProfileValidator = vine.compile(
+  vine.object({
+    firstName: vine.string().optional(),
+    lastName: vine.string().optional(),
+    dateOfBirth: vine
+      .date({ formats: { utc: true } })
+      .transform((date) => DateTime.fromJSDate(date))
+      .optional(),
+    phone: vine
+      .string()
+      .mobile().
+      optional(),
+    university: vine.string().in(universities.map((val) => val.id)).optional(),
+    course: vine.string().optional(),
+    curricularYear: vine.string().in(['1', '2', '3', '4', '5', 'already-finished']).optional(),
+    finishedAt: vine.number().range([1930, new Date().getFullYear()]).nullable().optional(),
+    municipality: vine.string().in(districts.map((dist) => dist.id)).optional(),
+    shirtSize: vine.string().in(shirts).optional(),
+    dietaryRestrictions: vine.string().trim().escape().nullable().optional(),
+    isVegetarian: vine.boolean().optional(),
+    isVegan: vine.boolean().optional(),
+    transports: vine.array(vine.string().in(transports.map((item) => item.id))).optional(),
+    heardAboutENEI: vine.string().in(heardaboutfrom.map((item) => item.value)).optional(),
+    reasonForSignup: vine.string().nullable().optional(),
+    attendedBeforeEditions: vine.array(vine.string().in(editions.map((item) => item.year.toString()))).optional(),
+    about: vine.string().optional().optional(),
+    github: vine.string().url().nullable().optional(),
+    linkedin: vine.string().url().nullable().optional(),
+    website: vine.string().url().nullable().optional(),
+  })
+)

--- a/website/app/validators/profile.ts
+++ b/website/app/validators/profile.ts
@@ -11,7 +11,6 @@ export const createProfileValidator = vine.compile(
   vine.object({
     firstName: vine.string(),
     lastName: vine.string(),
-    slug: vine.string(),
     dateOfBirth: vine
       .date({ formats: { utc: true } })
       .transform((date) => DateTime.fromJSDate(date)),

--- a/website/config/adminjs.ts
+++ b/website/config/adminjs.ts
@@ -8,14 +8,15 @@ import OrderResource from "../app/admin/resources/order_resource.js"
 import ProductResource from "../app/admin/resources/product_resource.js"
 import UserActivityResource from "../app/admin/resources/user_activity_resource.js"
 import UserActivity from "#models/user_activity"
-import User from "#models/user"
+import SpeakerProfileResource from "../app/admin/resources/speaker_profile_resource.js"
 
 const resources = [
   UserResource,
   PromoterProfileResource,
   UserActivityResource,
   OrderResource,
-  ProductResource
+  ProductResource,
+  SpeakerProfileResource,
 ]
 
 const adminjsConfig: AdminJSProviderConfig = {

--- a/website/database/migrations/1740847314811_create_company_profiles_table.ts
+++ b/website/database/migrations/1740847314811_create_company_profiles_table.ts
@@ -1,0 +1,19 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'company_profiles'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.timestamps({defaultToNow: true})
+
+      table.string('name').notNullable()
+      table.string('logo').notNullable()
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/website/database/migrations/1740847327843_create_speaker_profiles_table.ts
+++ b/website/database/migrations/1740847327843_create_speaker_profiles_table.ts
@@ -12,8 +12,9 @@ export default class extends BaseSchema {
       table.string('last_name').notNullable()
       table.string('job_title').notNullable()
       table.enum('speaker_role', ['keynote_speaker', 'panelist', 'moderator']).notNullable()
-      table.string('ORCID_link')
-      table.integer('company_id').references('id').inTable('company')
+      table.string('orcid_link').nullable()
+      table.string('about').nullable()
+      table.integer('company_id').references('id').inTable('company_profiles')
     })
   }
 

--- a/website/database/migrations/1740847327843_create_speaker_profiles_table.ts
+++ b/website/database/migrations/1740847327843_create_speaker_profiles_table.ts
@@ -11,6 +11,7 @@ export default class extends BaseSchema {
       table.string('first_name').notNullable()
       table.string('last_name').notNullable()
       table.string('job_title').notNullable()
+      table.enum('speaker_role', ['keynote_speaker', 'panelist', 'moderator']).notNullable()
       table.string('ORCID_link')
       table.integer('company_id').references('id').inTable('company')
     })

--- a/website/database/migrations/1740847327843_create_speaker_profiles_table.ts
+++ b/website/database/migrations/1740847327843_create_speaker_profiles_table.ts
@@ -1,0 +1,22 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'speaker_profiles'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.timestamps({defaultToNow: true})
+
+      table.string('first_name').notNullable()
+      table.string('last_name').notNullable()
+      table.string('job_title').notNullable()
+      table.string('ORCID_link')
+      table.integer('company_id').references('id').inTable('company')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/website/database/migrations/1740865376368_create_representative_profiles_table.ts
+++ b/website/database/migrations/1740865376368_create_representative_profiles_table.ts
@@ -1,0 +1,22 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'representative_profiles'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.timestamps({defaultToNow: true})
+
+      table.string('first_name').notNullable()
+      table.string('last_name').notNullable()
+      table.string('job_title').notNullable()
+      table.string('ORCID_link')
+      table.integer('company_id').references('id').inTable('company')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/website/database/migrations/1740868736242_alter_users_table.ts
+++ b/website/database/migrations/1740868736242_alter_users_table.ts
@@ -9,7 +9,7 @@ export default class extends BaseSchema {
         .unique()
         .references('id')
         .inTable('speaker_profiles')
-      table.integer('company_profile_id')
+      table.integer('company_id')
         .unique()
         .references('id')
         .inTable('company_profiles')

--- a/website/database/migrations/1740868736242_alter_users_table.ts
+++ b/website/database/migrations/1740868736242_alter_users_table.ts
@@ -1,0 +1,30 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'users'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.integer('speaker_profile_id')
+        .unique()
+        .references('id')
+        .inTable('speaker_profiles')
+      table.integer('company_profile_id')
+        .unique()
+        .references('id')
+        .inTable('company_profiles')
+      table.integer('representative_profile_id')
+        .unique()
+        .references('id')
+        .inTable('representative_profiles')
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('speaker_profile_id')
+      table.dropColumn('company_profile_id')
+      table.dropColumn('representative_profile_id')
+    })
+  }
+}

--- a/website/database/migrations/1740868736242_alter_users_table.ts
+++ b/website/database/migrations/1740868736242_alter_users_table.ts
@@ -17,6 +17,9 @@ export default class extends BaseSchema {
         .unique()
         .references('id')
         .inTable('representative_profiles')
+      table.string('slug')
+        .unique()
+        .nullable()
     })
   }
 
@@ -25,6 +28,7 @@ export default class extends BaseSchema {
       table.dropColumn('speaker_profile_id')
       table.dropColumn('company_profile_id')
       table.dropColumn('representative_profile_id')
+      table.dropColumn('slug')
     })
   }
 }

--- a/website/database/migrations/1741448595006_alter_participant_profiles_table.ts
+++ b/website/database/migrations/1741448595006_alter_participant_profiles_table.ts
@@ -1,0 +1,17 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'participant_profiles'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('slug')
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.string('slug').unique()
+    })
+  }
+}

--- a/website/database/seeders/2_account_seeder.dev.ts
+++ b/website/database/seeders/2_account_seeder.dev.ts
@@ -18,6 +18,7 @@ export default class extends BaseSeeder {
     const user = new User()
     user.email = email
     user.emailVerifiedAt = DateTime.now()
+    user.slug = 'jorge-costa'
 
     await user.related('accounts').create({
       id: `credentials:${email}`,
@@ -40,7 +41,6 @@ export default class extends BaseSeeder {
       isVegan: false,
       transports: ['carro'],
       attendedBeforeEditions: [],
-      slug: 'jorge-costa',
       about: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc laoreet eu enim vel semper. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum eu est vitae ex sodales consequat. In hac habitasse platea dictumst. Donec sed sodales arcu. Ut ultrices risus ipsum, sed iaculis libero auctor quis. Praesent eu fermentum enim, in egestas eros. Curabitur ac eros ut erat varius pretium eu eu turpis. Pellentesque tristique neque mauris. Morbi ultricies et justo sed suscipit. Praesent maximus arcu eu urna consequat consectetur. Nam pellentesque iaculis fringilla. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed sollicitudin massa orci, sed posuere mi imperdiet non.',
       github: 'https://github.com/JorgeCostaDevPT',
       website: 'https://eneiconf.pt'

--- a/website/database/seeders/2_account_seeder.dev.ts
+++ b/website/database/seeders/2_account_seeder.dev.ts
@@ -42,8 +42,8 @@ export default class extends BaseSeeder {
       attendedBeforeEditions: [],
       slug: 'jorge-costa',
       about: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc laoreet eu enim vel semper. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum eu est vitae ex sodales consequat. In hac habitasse platea dictumst. Donec sed sodales arcu. Ut ultrices risus ipsum, sed iaculis libero auctor quis. Praesent eu fermentum enim, in egestas eros. Curabitur ac eros ut erat varius pretium eu eu turpis. Pellentesque tristique neque mauris. Morbi ultricies et justo sed suscipit. Praesent maximus arcu eu urna consequat consectetur. Nam pellentesque iaculis fringilla. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed sollicitudin massa orci, sed posuere mi imperdiet non.',
-      github: 'JorgeCostaDevPT',
-      website: 'eneiconf.pt'
+      github: 'https://github.com/JorgeCostaDevPT',
+      website: 'https://eneiconf.pt'
     })
 
     // const profile = await PromoterProfile.create({})

--- a/website/database/seeders/2_account_seeder.dev.ts
+++ b/website/database/seeders/2_account_seeder.dev.ts
@@ -1,5 +1,7 @@
 import { logger } from '#lib/adonisjs/logger.js'
+import Company from '#models/company'
 import ParticipantProfile from '#models/participant_profile'
+import SpeakerProfile from '#models/speaker_profile'
 // import PromoterProfile from '#models/promoter_profile'
 import User from '#models/user'
 import app from '@adonisjs/core/services/app'
@@ -13,15 +15,39 @@ export default class extends BaseSeeder {
       return
     }
 
-    const email = 'test@eneiconf.pt'
+    const emailParticipant = 'test@eneiconf.pt'
 
-    const user = new User()
-    user.email = email
-    user.emailVerifiedAt = DateTime.now()
-    user.slug = 'jorge-costa'
+    const user1 = new User()
+    user1.email = emailParticipant
+    user1.emailVerifiedAt = DateTime.now()
+    user1.slug = 'jorge-costa'
 
-    await user.related('accounts').create({
-      id: `credentials:${email}`,
+    await user1.related('accounts').create({
+      id: `credentials:${emailParticipant}`,
+      password: 'password',
+    })
+
+    const emailSpeaker = 'speaker@eneiconf.pt'
+
+    const user2 = new User()
+    user2.email = emailSpeaker
+    user2.emailVerifiedAt = DateTime.now()
+    user2.slug = 'miguel-silva'
+
+    await user2.related('accounts').create({
+      id: `credentials:${emailSpeaker}`,
+      password: 'password',
+    })
+
+    const emailCompany = 'company@eneiconf.pt'
+
+    const user3 = new User()
+    user3.email = emailCompany
+    user3.emailVerifiedAt = DateTime.now()
+    user3.slug = 'google'
+
+    await user3.related('accounts').create({
+      id: `credentials:${emailCompany}`,
       password: 'password',
     })
 
@@ -48,6 +74,25 @@ export default class extends BaseSeeder {
 
     // const profile = await PromoterProfile.create({})
 
-    await user.related('participantProfile').associate(profile)
+    await user1.related('participantProfile').associate(profile)
+
+    const profile3 = await Company.create({
+      name: 'Google',
+      logo: 'https://cdn1.iconfinder.com/data/icons/google-s-logo/150/Google_Icons-09-1024.png',
+    })
+
+    const profile2 = await SpeakerProfile.create({
+      firstName: 'Miguel',
+      lastName: 'Silva',
+      jobTitle: 'Software Engineer',
+      speakerRole: 'keynote_speaker',
+      ORCIDLink: 'https://orcid.org/0000-0002-1825-0097',
+      about: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc laoreet eu enim vel semper. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum eu est vitae ex sodales consequat. In hac habitasse platea dictumst. Donec sed sodales arcu. Ut ultrices risus ipsum, sed iaculis libero auctor quis. Praesent eu fermentum enim, in egestas eros. Curabitur ac eros ut erat varius pretium eu eu turpis. Pellentesque tristique neque mauris. Morbi ultricies et justo sed suscipit. Praesent maximus arcu eu urna consequat consectetur. Nam pellentesque iaculis fringilla. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed sollicitudin massa orci, sed posuere mi imperdiet non.",
+    })
+
+    await user3.related('companyProfile').associate(profile3)
+    await user2.related('speakerProfile').associate(profile2)
+
+    await profile2.related('company').associate(profile3)
   }
 }

--- a/website/database/seeders/2_account_seeder.dev.ts
+++ b/website/database/seeders/2_account_seeder.dev.ts
@@ -38,7 +38,7 @@ export default class extends BaseSeeder {
       shirtSize: 'M',
       isVegetarian: false,
       isVegan: false,
-      transports: ['car'],
+      transports: ['carro'],
       attendedBeforeEditions: [],
       slug: 'jorge-costa',
       about: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc laoreet eu enim vel semper. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum eu est vitae ex sodales consequat. In hac habitasse platea dictumst. Donec sed sodales arcu. Ut ultrices risus ipsum, sed iaculis libero auctor quis. Praesent eu fermentum enim, in egestas eros. Curabitur ac eros ut erat varius pretium eu eu turpis. Pellentesque tristique neque mauris. Morbi ultricies et justo sed suscipit. Praesent maximus arcu eu urna consequat consectetur. Nam pellentesque iaculis fringilla. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed sollicitudin massa orci, sed posuere mi imperdiet non.',

--- a/website/database/seeders/2_account_seeder.dev.ts
+++ b/website/database/seeders/2_account_seeder.dev.ts
@@ -33,7 +33,7 @@ export default class extends BaseSeeder {
       course: 'M.EIC',
       curricularYear: '2',
       finishedAt: null,
-      municipality: 'Braga',
+      municipality: 'braga',
       heardAboutENEI: 'friends',
       shirtSize: 'M',
       isVegetarian: false,

--- a/website/database/seeders/2_account_seeder.dev.ts
+++ b/website/database/seeders/2_account_seeder.dev.ts
@@ -27,7 +27,6 @@ export default class extends BaseSeeder {
     const profile = await ParticipantProfile.create({
       firstName: 'Jorge',
       lastName: 'Costa',
-      slug: 'jorge-costa',
       dateOfBirth: DateTime.fromObject({ year: 2003, month: 5, day: 9 }),
       phone: '+351917777777',
       university: 'pt.up.fe',
@@ -41,6 +40,7 @@ export default class extends BaseSeeder {
       isVegan: false,
       transports: ['car'],
       attendedBeforeEditions: [],
+      slug: 'jorge-costa',
       about: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc laoreet eu enim vel semper. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum eu est vitae ex sodales consequat. In hac habitasse platea dictumst. Donec sed sodales arcu. Ut ultrices risus ipsum, sed iaculis libero auctor quis. Praesent eu fermentum enim, in egestas eros. Curabitur ac eros ut erat varius pretium eu eu turpis. Pellentesque tristique neque mauris. Morbi ultricies et justo sed suscipit. Praesent maximus arcu eu urna consequat consectetur. Nam pellentesque iaculis fringilla. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed sollicitudin massa orci, sed posuere mi imperdiet non.',
       github: 'JorgeCostaDevPT',
       website: 'eneiconf.pt'

--- a/website/database/seeders/2_account_seeder.dev.ts
+++ b/website/database/seeders/2_account_seeder.dev.ts
@@ -27,6 +27,7 @@ export default class extends BaseSeeder {
     const profile = await ParticipantProfile.create({
       firstName: 'Jorge',
       lastName: 'Costa',
+      slug: 'jorge-costa',
       dateOfBirth: DateTime.fromObject({ year: 2003, month: 5, day: 9 }),
       phone: '+351917777777',
       university: 'pt.up.fe',
@@ -39,7 +40,10 @@ export default class extends BaseSeeder {
       isVegetarian: false,
       isVegan: false,
       transports: ['car'],
-      attendedBeforeEditions: []
+      attendedBeforeEditions: [],
+      about: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc laoreet eu enim vel semper. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum eu est vitae ex sodales consequat. In hac habitasse platea dictumst. Donec sed sodales arcu. Ut ultrices risus ipsum, sed iaculis libero auctor quis. Praesent eu fermentum enim, in egestas eros. Curabitur ac eros ut erat varius pretium eu eu turpis. Pellentesque tristique neque mauris. Morbi ultricies et justo sed suscipit. Praesent maximus arcu eu urna consequat consectetur. Nam pellentesque iaculis fringilla. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed sollicitudin massa orci, sed posuere mi imperdiet non.',
+      github: 'JorgeCostaDevPT',
+      website: 'eneiconf.pt'
     })
 
     // const profile = await PromoterProfile.create({})

--- a/website/inertia/components/common/navbar.tsx
+++ b/website/inertia/components/common/navbar.tsx
@@ -99,6 +99,11 @@ export function Navbar({ className, variant = "blue" }: { className?: string, va
             </Link>
             <div className='flex gap-4 items-center justify-between'>
               <div className={auth.state === 'authenticated' ? 'block' : 'hidden'}>
+                <Link route="pages:profile.default" className={cn("", `text-${textColor}`)}>
+                    <span>Perfil</span>
+                </Link>
+              </div>
+              <div className={auth.state === 'authenticated' ? 'block' : 'hidden'}>
                 <Link route="pages:store" className={cn("", `text-${textColor}`)}>
                     <span>Loja</span>
                 </Link>

--- a/website/inertia/components/signup/2_student_info.tsx
+++ b/website/inertia/components/signup/2_student_info.tsx
@@ -17,22 +17,12 @@ import { cn } from '~/lib/utils'
 import { Input } from '../ui/input'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { EducationInfo, educationInfoSchema } from '~/pages/signup/schema'
-import { getUniversityById, universities } from '~/lib/enei/signup/universities'
-import { useMemo } from 'react'
+import { universities } from '~/lib/enei/signup/universities'
 import { useStepper } from '../ui/stepper'
 import { useAtom, useSetAtom } from 'jotai/react'
 import { educationInfoAtom } from '~/pages/signup/atoms'
 import StepperFormActions from './actions'
-
-function UniversitySelection({ value }: { value?: string }) {
-  const name = useMemo(() => value && getUniversityById(value)?.name, [value])
-
-  return name ? (
-    <span className="max-w-full overflow-ellipsis overflow-hidden">{name}</span>
-  ) : (
-    <span>Selecionar Universidade...</span>
-  )
-}
+import UniversitySelection from './common/university_selection'
 
 function EducationInfoForm() {
   const { nextStep } = useStepper()

--- a/website/inertia/components/signup/3_logistics_info.tsx
+++ b/website/inertia/components/signup/3_logistics_info.tsx
@@ -2,23 +2,16 @@ import { useForm } from 'react-hook-form'
 import { Checkbox } from '../ui/checkbox'
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../ui/form'
 import { Input } from '../ui/input'
-import MultipleSelector, { Option } from '../ui/multiple-selector'
+import MultipleSelector from '../ui/multiple-selector'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import { LogisticsInfo, logisticsInfoSchema } from '~/pages/signup/schema'
-import transports from '#data/enei/signup/transports.json' with { type: 'json' }
 import sizes from '#data/enei/signup/shirts.json' with { type: 'json' }
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useStepper } from '../ui/stepper'
 import { useAtom, useSetAtom } from 'jotai/react'
 import { logisticsInfoAtom } from '~/pages/signup/atoms'
 import StepperFormActions from './actions'
-
-const TRANSPORTS: Option[] = transports.map(({ id, description }) => {
-  return {
-    label: description,
-    value: id,
-  }
-})
+import { TRANSPORTS } from '~/lib/enei/signup/transports'
 
 const SIZES = sizes
 

--- a/website/inertia/components/signup/4_communication_info.tsx
+++ b/website/inertia/components/signup/4_communication_info.tsx
@@ -118,7 +118,10 @@ const CommunicationInfoForm = () => {
               <FormItem>
                 <FormLabel className="flex gap-2 items-center">
                   <FormControl>
-                    <Checkbox checked={field.value} onCheckedChange={field.onChange} />
+                    <Checkbox checked={field.value} onCheckedChange={(checked) => {
+                      field.onChange(checked)
+                      if (!checked) form.setValue("attendedBeforeEditions", [], { shouldDirty: true })
+                    }} />
                   </FormControl>
                   <p>Já participaste em alguma edição do ENEI?</p>
                 </FormLabel>

--- a/website/inertia/components/signup/4_communication_info.tsx
+++ b/website/inertia/components/signup/4_communication_info.tsx
@@ -6,7 +6,6 @@ import MultipleSelector, { Option } from '../ui/multiple-selector'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import { Textarea } from '../ui/textarea'
 
-import editions from '#data/enei/editions.json' with { type: 'json' }
 import heardaboutfrom from '#data/enei/signup/heard-about.json' with { type: 'json' }
 import { zodResolver } from '@hookform/resolvers/zod'
 import {
@@ -23,15 +22,7 @@ import {
 import StepperFormActions from './actions'
 import { PageProps } from '@adonisjs/inertia/types'
 import { router, usePage } from '@inertiajs/react'
-
-const ENEI_EDITIONS: Option[] = editions
-  .sort((a, b) => b.year - a.year)
-  .map(({ year, location }) => {
-    return {
-      label: location + ', ' + year.toString(),
-      value: year.toString(),
-    }
-  })
+import { ENEI_EDITIONS } from '~/lib/enei/signup/editions'
 
 const HEARD_ABOUT_FROM: Option[] = heardaboutfrom
 
@@ -69,7 +60,7 @@ const CommunicationInfoForm = () => {
       ...data,
       _csrf: csrfToken
     }
-    
+
     router.post(tuyau.$url('actions:signup'), payload)
   }
 

--- a/website/inertia/components/signup/common/university_selection.tsx
+++ b/website/inertia/components/signup/common/university_selection.tsx
@@ -1,0 +1,12 @@
+import { useMemo } from 'react'
+import { getUniversityById } from '~/lib/enei/signup/universities'
+
+export default function UniversitySelection({ value }: { value?: string }) {
+  const name = useMemo(() => value && getUniversityById(value)?.name, [value])
+
+  return name ? (
+    <span className="max-w-full overflow-ellipsis overflow-hidden">{name}</span>
+  ) : (
+    <span>Selecionar Universidade...</span>
+  )
+}

--- a/website/inertia/components/signup/input/curricular_year_input.tsx
+++ b/website/inertia/components/signup/input/curricular_year_input.tsx
@@ -71,7 +71,7 @@ const CurricularYearSelector = ({
 
       {/* State Selector - Only shown if degree already finished */}
       {selectedCurricularYear === 'already-finished' && (
-        <Select onValueChange={handleLastYearSelect}>
+        <Select defaultValue={defaultValue[1]?.toString()} onValueChange={handleLastYearSelect}>
           <SelectTrigger>
             <SelectValue placeholder="Ano de Conclusão" />
           </SelectTrigger>

--- a/website/inertia/lib/enei/signup/editions.ts
+++ b/website/inertia/lib/enei/signup/editions.ts
@@ -1,0 +1,11 @@
+import { Option } from "~/components/ui/multiple-selector"
+import editions from '#data/enei/editions.json' with { type: 'json' }
+
+export const ENEI_EDITIONS: Option[] = editions
+  .sort((a, b) => b.year - a.year)
+  .map(({ year, location }) => {
+    return {
+      label: location + ', ' + year.toString(),
+      value: year.toString(),
+    }
+  })

--- a/website/inertia/lib/enei/signup/transports.ts
+++ b/website/inertia/lib/enei/signup/transports.ts
@@ -1,0 +1,9 @@
+import { Option } from '~/components/ui/multiple-selector'
+import transports from '#data/enei/signup/transports.json' with { type: 'json' }
+
+export const TRANSPORTS: Option[] = transports.map(({ id, description }) => {
+  return {
+    label: description,
+    value: id,
+  }
+})

--- a/website/inertia/pages/profile/edit/page.tsx
+++ b/website/inertia/pages/profile/edit/page.tsx
@@ -7,7 +7,7 @@ import Container from '~/components/common/containers'
 import { getUniversityById } from '~/lib/enei/signup/universities'
 import { Badge } from '~/components/ui/badge'
 import { Card } from '~/components/ui/card'
-import { CommunicationsInfo, communicationsInfoSchema, EducationInfo, educationInfoSchema, LogisticsInfo, logisticsInfoSchema, PersonalInfo, personalInfoSchema } from '~/pages/signup/schema'
+import { AdditionalInfo, additionalInfoSchema, CommunicationsInfo, communicationsInfoSchema, EducationInfo, educationInfoSchema, LogisticsInfo, logisticsInfoSchema, PersonalInfo, personalInfoSchema } from '~/pages/signup/schema'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import {
@@ -84,12 +84,14 @@ type CommonInfo =
   & EducationInfo
   & LogisticsInfo
   & CommunicationsInfo
+  & AdditionalInfo
 
 const commonSchema = z.object({
   ...personalInfoSchema.shape,
   ...educationInfoSchema.shape,
   ...logisticsInfoSchema.shape,
   ...communicationsInfoSchema.shape,
+  ...additionalInfoSchema.shape,
 })
 
 export default function ProfilePage(props: InferPageProps<ProfilesController, 'index'> & { profile: ParticipantProfile }) {
@@ -123,14 +125,16 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
       attendedBefore: false,
       attendedBeforeEditions: [],
       termsAndConditions: false,
+      about: '',
+      github: '',
+      linkedin: '',
+      website: '',
     },
   })
-
 
   const onSubmit = (data: CommonInfo) => {
     console.log(data)
   }
-
 
   return (
     <Page title={`${profile.firstName} ${profile.lastName}`} className="bg-enei-beige text-enei-blue">
@@ -358,15 +362,63 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
                   />
                 )}
 
+                <FormField
+                  control={form.control}
+                  name="about"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Sobre</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          placeholder="Aprender novas tecnologias, melhorar soft skills..."
+                          className="resize-none"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="github"
+                  render={({ field }) => (
+                    <FormItem className="flex-1">
+                      <FormLabel>Username do GitHub</FormLabel>
+                      <FormControl>
+                        <Input placeholder="NIAEFEUP" type="text" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="linkedin"
+                  render={({ field }) => (
+                    <FormItem className="flex-1">
+                      <FormLabel>Username do Linkedin</FormLabel>
+                      <FormControl>
+                        <Input placeholder="NIAEFEUP" type="text" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="website"
+                  render={({ field }) => (
+                    <FormItem className="flex-1">
+                      <FormLabel>Website Pessoal</FormLabel>
+                      <FormControl>
+                        <Input placeholder="ni.fe.up.pt" type="text" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
                 { /* TODO: */}
-                <br />
-                Sobre: {profile.about}
-                <br />
-                GitHub: {profile.github}
-                <br />
-                LinkedIn: {profile.linkedin}
-                <br />
-                Website: {profile.website}
                 <br />
                 foto de perfil: // todo
                 <br />

--- a/website/inertia/pages/profile/edit/page.tsx
+++ b/website/inertia/pages/profile/edit/page.tsx
@@ -101,10 +101,9 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
 
   const socials: SocialIconProps[] = []
 
-  if (profile.github) socials.push({ icon: Github, link: `https://github.com/${profile.github}` })
-  if (profile.linkedin) socials.push({ icon: Linkedin, link: `https://linkedin.com/in/${profile.linkedin}` })
-  if (profile.website) socials.push({ icon: Globe, link: `//${profile.website}` })
-
+  if (profile.github) socials.push({ icon: Github, link: profile.github })
+  if (profile.linkedin) socials.push({ icon: Linkedin, link: profile.linkedin })
+  if (profile.website) socials.push({ icon: Globe, link: profile.website })
 
   const form = useForm<CommonInfo>({
     resolver: zodResolver(commonSchema),
@@ -384,7 +383,7 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
                   name="github"
                   render={({ field }) => (
                     <FormItem className="flex-1">
-                      <FormLabel>Username do GitHub</FormLabel>
+                      <FormLabel>URL do teu GitHub</FormLabel>
                       <FormControl>
                         <Input placeholder="NIAEFEUP" type="text" {...field} />
                       </FormControl>
@@ -397,7 +396,7 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
                   name="linkedin"
                   render={({ field }) => (
                     <FormItem className="flex-1">
-                      <FormLabel>Username do Linkedin</FormLabel>
+                      <FormLabel>URL do teu Linkedin</FormLabel>
                       <FormControl>
                         <Input placeholder="NIAEFEUP" type="text" {...field} />
                       </FormControl>
@@ -410,7 +409,7 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
                   name="website"
                   render={({ field }) => (
                     <FormItem className="flex-1">
-                      <FormLabel>Website Pessoal</FormLabel>
+                      <FormLabel>URL do teu Website Pessoal</FormLabel>
                       <FormControl>
                         <Input placeholder="ni.fe.up.pt" type="text" {...field} />
                       </FormControl>

--- a/website/inertia/pages/profile/edit/page.tsx
+++ b/website/inertia/pages/profile/edit/page.tsx
@@ -277,7 +277,10 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
                     <FormItem>
                       <FormLabel className="flex gap-2 items-center">
                         <FormControl>
-                          <Checkbox checked={field.value} onCheckedChange={field.onChange} />
+                          <Checkbox checked={field.value} onCheckedChange={(checked) => {
+                            field.onChange(checked)
+                            if (!checked) form.setValue("attendedBeforeEditions", [], { shouldDirty: true })
+                          }} />
                         </FormControl>
                         <p>Já participaste em alguma edição do ENEI?</p>
                       </FormLabel>

--- a/website/inertia/pages/profile/edit/page.tsx
+++ b/website/inertia/pages/profile/edit/page.tsx
@@ -121,7 +121,7 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
   const { profile }: { profile: ParticipantProfile } = props
   const { csrfToken } = usePage<PageProps & { csrfToken: string; }>().props;
 
-  const [initialValues, _] = useState<CommonInfo>(profileToCommonInfo(profile))
+  const [initialValues, ] = useState<CommonInfo>(profileToCommonInfo(profile))
 
   const form = useForm<CommonInfo>({
     resolver: zodResolver(commonSchema),

--- a/website/inertia/pages/profile/edit/page.tsx
+++ b/website/inertia/pages/profile/edit/page.tsx
@@ -162,7 +162,7 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
                     name="firstName"
                     render={({ field }) => (
                       <FormItem className="flex-1">
-                        <FormLabel>Primeiro Nome*</FormLabel>
+                        <FormLabel>Primeiro Nome</FormLabel>
                         <FormControl>
                           <Input placeholder="Joca" type="text" {...field} />
                         </FormControl>
@@ -175,7 +175,7 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
                     name="lastName"
                     render={({ field }) => (
                       <FormItem className="flex-1">
-                        <FormLabel>Último Nome*</FormLabel>
+                        <FormLabel>Último Nome</FormLabel>
                         <FormControl>
                           <Input placeholder="Costa" type="text" {...field} />
                         </FormControl>
@@ -189,7 +189,7 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
                   name="university"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Universidade/Faculdade*</FormLabel>
+                      <FormLabel>Universidade/Faculdade</FormLabel>
                       <Popover>
                         <PopoverTrigger asChild>
                           <Button
@@ -211,7 +211,7 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
                                   <CommandItem
                                     key={id}
                                     value={name.toLowerCase()}
-                                    onSelect={() => form.setValue(field.name, id)}
+                                    onSelect={() => form.setValue(field.name, id, { shouldDirty: true })}
                                     className="flex cursor-pointer items-center justify-between text-sm"
                                   >
                                     <span>{name}</span>
@@ -237,7 +237,7 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
                   name="course"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Curso*</FormLabel>
+                      <FormLabel>Curso</FormLabel>
                       <FormControl>
                         <Input
                           onChange={field.onChange}
@@ -254,7 +254,7 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
                   name="curricularYear"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Ano Curricular*</FormLabel>
+                      <FormLabel>Ano Curricular</FormLabel>
                       <FormControl>
                         <CurricularYearSelector
                           defaultValue={form.getValues('curricularYear')}
@@ -262,7 +262,7 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
                             form.setValue(field.name, [
                               curricularYear,
                               lastYear || null,
-                            ] as CurricularYearSelectorType)
+                            ] as CurricularYearSelectorType, { shouldDirty: true })
                           }}
                         />
                       </FormControl>
@@ -384,7 +384,7 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
                   name="dateOfBirth"
                   render={({ field }) => (
                     <FormItem className="flex flex-col">
-                      <FormLabel>Data de Nascimento*</FormLabel>
+                      <FormLabel>Data de Nascimento</FormLabel>
                       <Popover>
                         <PopoverTrigger asChild>
                           <FormControl>
@@ -423,7 +423,7 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
                   name="phone"
                   render={({ field }) => (
                     <FormItem className="flex flex-col items-start">
-                      <FormLabel>Número de telemóvel*</FormLabel>
+                      <FormLabel>Número de telemóvel</FormLabel>
                       <FormControl className="w-full">
                         <PhoneInput
                           placeholder="923 456 789"
@@ -443,7 +443,7 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
                   name="municipality"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Natural de*</FormLabel>
+                      <FormLabel>Natural de</FormLabel>
                       <FormControl>
                         <Select onValueChange={field.onChange} defaultValue={field.value}>
                           <SelectTrigger>
@@ -472,7 +472,7 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
                   name="shirtSize"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Tamanho da T-shirt*</FormLabel>
+                      <FormLabel>Tamanho da T-shirt</FormLabel>
                       <FormControl>
                         <Select onValueChange={field.onChange} defaultValue={field.value}>
                           <SelectTrigger>

--- a/website/inertia/pages/profile/edit/page.tsx
+++ b/website/inertia/pages/profile/edit/page.tsx
@@ -1,50 +1,149 @@
 import { InferPageProps } from '@adonisjs/inertia/types'
 import ProfilesController from '#controllers/profiles_controller'
 import ParticipantProfile from '#models/participant_profile'
-import { Card } from '~/components/ui/card'
 import { Button } from '~/components/ui/button'
 import Page from '~/components/common/page'
 import Container from '~/components/common/containers'
 import { getUniversityById } from '~/lib/enei/signup/universities'
-import { Download, EyeOff, User, Github, Instagram, Linkedin, Globe, LucideProps } from 'lucide-react'
+import { Badge } from '~/components/ui/badge'
+import { Card } from '~/components/ui/card'
+import { CommunicationsInfo, communicationsInfoSchema, EducationInfo, educationInfoSchema, LogisticsInfo, logisticsInfoSchema, PersonalInfo, personalInfoSchema } from '~/pages/signup/schema'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '~/components/ui/form'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '~/components/ui/command'
+import {
+  Download,
+  User,
+  Github,
+  Linkedin,
+  Globe,
+  LucideProps,
+  Eye,
+  EyeOff,
+  CalendarIcon,
+  Check,
+  ChevronsUpDown,
+} from 'lucide-react'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '~/components/ui/select'
+import { Input } from '~/components/ui/input'
+import { Popover, PopoverContent, PopoverTrigger } from '~/components/ui/popover'
+import { Calendar } from '~/components/ui/calendar'
+import { Checkbox } from '~/components/ui/checkbox'
+import { format } from 'date-fns'
+import { pt } from 'date-fns/locale'
+import { cn } from '~/lib/utils'
+import { PhoneInput } from '~/components/ui/phone-input/phone-input'
+import { z } from 'zod'
+import CurricularYearSelector, { CurricularYearSelectorType } from '~/components/signup/input/curricular_year_input'
+import UniversitySelection from '~/components/signup/common/university_selection'
+import districts from '#data/enei/districts.json' with { type: 'json' }
+import sizes from '#data/enei/signup/shirts.json' with { type: 'json' }
+import heardaboutfrom from '#data/enei/signup/heard-about.json' with { type: 'json' }
+import { universities } from '~/lib/enei/signup/universities'
+import { ENEI_EDITIONS } from '~/lib/enei/signup/editions'
+import MultipleSelector, { Option } from '~/components/ui/multiple-selector'
+import { TRANSPORTS } from '~/lib/enei/signup/transports'
+import { Textarea } from '~/components/ui/textarea'
 
+// TODO: Refactor exists in profile/page.tsx
 interface SocialIconProps {
   icon: React.FC<LucideProps>;
   link: string;
 }
 
-function SocialIcon({ icon: Icon, link }: SocialIconProps) {
+const INITIAL_MONTH = new Date(2004, 0, 1)
+const SIZES = sizes
+const HEARD_ABOUT_FROM: Option[] = heardaboutfrom
+
+const SocialIcon = ({ icon: Icon, link }: SocialIconProps) => {
   return (
-    <a href={link} className='border-2 border-enei-blue rounded-full h-9 w-9 flex justify-center items-center'>
+    <a href={link} className='border-2 border-enei-blue rounded-full h-9 w-9 flex justify-center items-center' target="_blank" rel="noopener noreferrer">
       <Icon className='h-5' />
     </a>
   )
 }
 
-export default function ProfileEditPage(props: InferPageProps<ProfilesController, 'index'> & { profile: ParticipantProfile }) {
-  const { profile, isUser } = props
+type CommonInfo =
+  & PersonalInfo
+  & EducationInfo
+  & LogisticsInfo
+  & CommunicationsInfo
 
-  /*
-  const districts_dict = districts.reduce(
-    (dict: { [id: string]: string; }, el: { id: string; name: string }, _) => (dict[el.id] = el.name, dict),
-    {}
-  );
-  */
+const commonSchema = z.object({
+  ...personalInfoSchema.shape,
+  ...educationInfoSchema.shape,
+  ...logisticsInfoSchema.shape,
+  ...communicationsInfoSchema.shape,
+})
 
-  // districts.find(({ id: universityId }) => universityId === id)
+export default function ProfilePage(props: InferPageProps<ProfilesController, 'index'> & { profile: ParticipantProfile }) {
+  const { profile } = props
+
+  const profileEditions = ENEI_EDITIONS.filter((edition) => profile.attendedBeforeEditions.includes(edition.value)).map((edition) => edition.label)
+
+  const socials: SocialIconProps[] = []
+
+  if (profile.github) socials.push({ icon: Github, link: `https://github.com/${profile.github}` })
+  if (profile.linkedin) socials.push({ icon: Linkedin, link: `https://linkedin.com/in/${profile.linkedin}` })
+  if (profile.website) socials.push({ icon: Globe, link: `//${profile.website}` })
+
+
+  const form = useForm<CommonInfo>({
+    resolver: zodResolver(commonSchema),
+    defaultValues: {
+      firstName: '',
+      lastName: '',
+      phone: '',
+      university: '',
+      course: '',
+      curricularYear: ['1', null] as CurricularYearSelectorType,
+      shirtSize: '',
+      dietaryRestrictions: '',
+      isVegetarian: false,
+      isVegan: false,
+      transports: [],
+      heardAboutENEI: '',
+      reasonForSignup: '',
+      attendedBefore: false,
+      attendedBeforeEditions: [],
+      termsAndConditions: false,
+    },
+  })
+
+
+  const onSubmit = (data: CommonInfo) => {
+    console.log(data)
+  }
+
 
   return (
-    <Page title="Perfil" className="bg-enei-blue text-white">
-      <Container>
-        <section className="relative flex flex-col gap-8 md:justify-between z-10">
-          <Card className='p-4 flex flex-col gap-4'>
+    <Page title={`${profile.firstName} ${profile.lastName}`} className="bg-enei-beige text-enei-blue">
+      <Container className='mt-8'>
+        <Card className='p-4'>
+          <section className="relative flex flex-col gap-8 md:justify-between z-10">
             <h3 className='text-2xl'>Perfil do Participante</h3>
 
-            <section className='grid sm:grid-cols-[auto_1fr] items-center gap-4 sm:gap-8'>
-              <div className='size-fit rounded-sm bg-enei-beige mx-auto sm:mx-0'>
-                <User className='w-48 h-48' />
+            <section className='grid md:grid-cols-[auto_1fr] items-center gap-4 md:gap-8'>
+              <div className='size-fit rounded-sm bg-enei-blue mx-auto md:mx-0'>
+                <User className='w-48 h-48 text-enei-beige' />
               </div>
-              <div className='h-full flex flex-col gap-2 justify-between py-0 md:py-4 text-center sm:text-start'>
+              <div className='h-full flex flex-col gap-2 justify-between text-center md:text-start'>
                 <p className='text-3xl'>
                   {profile.firstName} {profile.lastName}
                 </p>
@@ -52,64 +151,462 @@ export default function ProfileEditPage(props: InferPageProps<ProfilesController
                   <p className='text-lg'> {profile.course} &#183; {(profile.curricularYear === 'already-finished') ? ("Concluído em " + profile.finishedAt) : (profile.curricularYear + "º ano")} </p>
                   <p className='text-lg'> @ {getUniversityById(profile.university)!.name} </p>
                 </div>
-                <div className='flex flex-row gap-2 justify-center sm:justify-start'>
-                  <SocialIcon icon={Github} link={"https://github.com"} />
-                  <SocialIcon icon={Instagram} link={"https://instagram.com"} />
-                  <SocialIcon icon={Linkedin} link={"https://linkedin.com"} />
-                  <SocialIcon icon={Globe} link={"https://google.com"} />
-                  <Button className='w-fit'>
-                    <Download />
-                    Currículo
-                  </Button>
+                <div className='flex flex-row flex-wrap gap-2 justify-center md:justify-start'>
+                  {socials.length > 0 &&
+                    socials.map((social: SocialIconProps) => (
+                      <SocialIcon {...social} />
+                    ))
+                  }
+                  <div className='flex flex-row gap-2'>
+                    <Button className='w-fit'>
+                      <Download />
+                      Currículo
+                    </Button>
+                  </div>
                 </div>
+                {profileEditions.length > 0 ?
+                  <div className='flex flex-row flex-wrap gap-2 justify-center md:justify-normal'>
+                    {profileEditions.map((edition) => (
+                      <Badge>
+                        {edition}
+                      </Badge>
+                    ))}
+                  </div>
+                  :
+                  <div>
+                    <Badge variant={'default'}>
+                      Primeiro ENEI
+                    </Badge>
+                  </div>
+                }
               </div>
             </section>
-            <section>
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-              </p>
+            <section className='grid grid-rows-[auto_1fr] gap-4 mt-4'>
+              <div>
+                <h4 className='font-bold text-lg text-center md:text-left'>
+                  Sobre
+                </h4>
+                <p>
+                  {profile.about ?? "Sem informação."}
+                </p>
+              </div>
             </section>
-            {isUser &&
-              <section>
+          </section>
+
+
+
+
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)}>
+              <div className="flex flex-col gap-4">
+                <div className='grid grid-cols-[auto_1fr] gap-2 items-center my-2'>
+                  <Eye />
+                  <p> <span className='font-bold'> Visível: </span> As informações a baixo estão visíveis no teu perfil. </p>
+                </div>
+
+                <div className="flex gap-2">
+                  <FormField
+                    control={form.control}
+                    name="firstName"
+                    render={({ field }) => (
+                      <FormItem className="flex-1">
+                        <FormLabel>Primeiro Nome*</FormLabel>
+                        <FormControl>
+                          <Input placeholder="Joca" type="text" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="lastName"
+                    render={({ field }) => (
+                      <FormItem className="flex-1">
+                        <FormLabel>Último Nome*</FormLabel>
+                        <FormControl>
+                          <Input placeholder="Costa" type="text" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+                <FormField
+                  control={form.control}
+                  name="university"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Universidade/Faculdade*</FormLabel>
+                      <Popover>
+                        <PopoverTrigger asChild>
+                          <Button
+                            variant="outline"
+                            role="combobox"
+                            className="w-full justify-between overflow-ellipsis font-normal"
+                          >
+                            <UniversitySelection value={field.value} />
+                            <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
+                          </Button>
+                        </PopoverTrigger>
+                        <PopoverContent className="p-0">
+                          <Command>
+                            <CommandInput placeholder="Procurar universidade..." />
+                            <CommandList>
+                              <CommandEmpty>Nenhuma universidade encontrada</CommandEmpty>
+                              <CommandGroup>
+                                {universities.map(({ id, name }) => (
+                                  <CommandItem
+                                    key={id}
+                                    value={name.toLowerCase()}
+                                    onSelect={() => form.setValue(field.name, id)}
+                                    className="flex cursor-pointer items-center justify-between text-sm"
+                                  >
+                                    <span>{name}</span>
+                                    <Check
+                                      className={cn(
+                                        'h-4 w-4',
+                                        field.value === id ? 'opacity-100' : 'opacity-0'
+                                      )}
+                                    />
+                                  </CommandItem>
+                                ))}
+                              </CommandGroup>
+                            </CommandList>
+                          </Command>
+                        </PopoverContent>
+                      </Popover>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="course"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Curso*</FormLabel>
+                      <FormControl>
+                        <Input
+                          onChange={field.onChange}
+                          defaultValue={field.value}
+                          placeholder="Introduz o teu curso"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="curricularYear"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Ano Curricular*</FormLabel>
+                      <FormControl>
+                        <CurricularYearSelector
+                          defaultValue={form.getValues('curricularYear')}
+                          onCurricularYearChange={(curricularYear, lastYear) => {
+                            form.setValue(field.name, [
+                              curricularYear,
+                              lastYear || null,
+                            ] as CurricularYearSelectorType)
+                          }}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="attendedBefore"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="flex gap-2 items-center">
+                        <FormControl>
+                          <Checkbox checked={field.value} onCheckedChange={field.onChange} />
+                        </FormControl>
+                        <p>Já participaste em alguma edição do ENEI?</p>
+                      </FormLabel>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                {form.watch('attendedBefore') && (
+                  <FormField
+                    control={form.control}
+                    name="attendedBeforeEditions"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Em qual edição?</FormLabel>
+                        <FormControl>
+                          <MultipleSelector
+                            {...field}
+                            defaultOptions={ENEI_EDITIONS}
+                            emptyIndicator={
+                              <p className="text-center text-lg leading-10 text-gray-600 dark:text-gray-400">
+                                Sem resultados
+                              </p>
+                            }
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                )}
+
+                { /* TODO: */}
+                <br />
+                Sobre: {profile.about}
+                <br />
+                GitHub: {profile.github}
+                <br />
+                LinkedIn: {profile.linkedin}
+                <br />
+                Website: {profile.website}
+                <br />
+                foto de perfil: // todo
+                <br />
+                Currículo: // TODO
+
                 <div className='grid grid-cols-[auto_1fr] gap-2 items-center my-2'>
                   <EyeOff />
-                  <p> As informações a baixo estão visíveis apenas para ti. </p>
+                  <p> <span className='font-bold'> Invisível: </span> As informações a baixo não estão visíveis no teu perfil. </p>
                 </div>
-                Primeiro Nome: {profile.firstName}
-                <br />
-                Último Nome: {profile.lastName}
-                <br />
-                Data de Nascimento: {profile.dateOfBirth.toLocaleString()}
-                <br />
-                Número de Telemóvel: {profile.phone}
-                <br />
-                Natural de: {profile.municipality}
-                <br />
-                Universidade/Faculdade: {profile.university}
-                <br />
-                Curso: {profile.course}
-                <br />
-                Ano Curricular: {profile.curricularYear} {profile.finishedAt}
-                <br />
-                Tamanho da T-Shirt: {profile.shirtSize}
-                <br />
-                Restrições Alimentares: {profile.dietaryRestrictions}
-                <br />
-                Vegetariano?: {profile.isVegetarian}
-                <br />
-                Vegan?: {profile.isVegan}
-                <br />
-                Como estou a pensar deslocar-me para o evento: {profile.transports}
-                <br />
-                Como ouviste falar do ENEI?: {profile.heardAboutEnei}
-                <br />
-                Qual a principal razão para te inscreveres no ENEI?: {profile.reasonForSignup}
-                <br />
-                Já participaste em alguma edição do ENEI?: {profile.attendedBeforeEditions}
-              </section>
-            }
-          </Card>
-        </section>
+
+                <FormField
+                  control={form.control}
+                  name="dateOfBirth"
+                  render={({ field }) => (
+                    <FormItem className="flex flex-col">
+                      <FormLabel>Data de Nascimento*</FormLabel>
+                      <Popover>
+                        <PopoverTrigger asChild>
+                          <FormControl>
+                            <Button
+                              variant={'outline'}
+                              className={cn(
+                                'w-[240px] pl-3 text-left font-normal',
+                                !field.value && 'text-muted-foreground'
+                              )}
+                            >
+                              {field.value ? (
+                                format(field.value, 'PPP', { locale: pt })
+                              ) : (
+                                <span>Seleciona uma data</span>
+                              )}
+                              <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                            </Button>
+                          </FormControl>
+                        </PopoverTrigger>
+                        <PopoverContent className="w-auto p-0" align="start">
+                          <Calendar
+                            mode="single"
+                            initialMonth={INITIAL_MONTH}
+                            selected={field.value}
+                            onSelect={field.onChange}
+                            locale={pt}
+                          />
+                        </PopoverContent>
+                      </Popover>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="phone"
+                  render={({ field }) => (
+                    <FormItem className="flex flex-col items-start">
+                      <FormLabel>Número de telemóvel*</FormLabel>
+                      <FormControl className="w-full">
+                        <PhoneInput
+                          placeholder="923 456 789"
+                          defaultCountry="PT"
+                          locales="pt"
+                          countryOptionsOrder={['PT', '...']}
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormDescription>Não incluas o código do país.</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="municipality"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Natural de*</FormLabel>
+                      <FormControl>
+                        <Select onValueChange={field.onChange} defaultValue={field.value}>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Selecionar distrito/região autónoma" />
+                          </SelectTrigger>
+
+                          <SelectContent>
+                            {districts.map((dist) => {
+                              return (
+                                <SelectItem key={dist.id} value={dist.id}>
+                                  {dist.name}
+                                </SelectItem>
+                              )
+                            })}
+                          </SelectContent>
+                        </Select>
+                      </FormControl>
+                      <FormDescription>Indica o distrito onde nasceste.</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="shirtSize"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Tamanho da T-shirt*</FormLabel>
+                      <FormControl>
+                        <Select onValueChange={field.onChange} defaultValue={field.value}>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Selecionar tamanho" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {SIZES.map((size) => {
+                              return <SelectItem key={size} value={size}>{size}</SelectItem>
+                            })}
+                          </SelectContent>
+                        </Select>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                {/* Restrições Alimentares */}
+                <FormField
+                  control={form.control}
+                  name="dietaryRestrictions"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Restrições alimentares</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Intolerâncias, alergias, etc." {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="isVegetarian"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="flex gap-2 items-center">
+                        <FormControl>
+                          <Checkbox checked={field.value} onCheckedChange={field.onChange} />
+                        </FormControl>
+                        <p>Vegetariano?</p>
+                      </FormLabel>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                {/* Vegan? */}
+                <FormField
+                  control={form.control}
+                  name="isVegan"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="flex gap-2 items-center">
+                        <FormControl>
+                          <Checkbox checked={field.value} onCheckedChange={field.onChange} />
+                        </FormControl>
+                        <p>Vegan?</p>
+                      </FormLabel>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                {/* Transporte até ao evento */}
+                <FormField
+                  control={form.control}
+                  name="transports"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Como estou a pensar deslocar-me para o evento</FormLabel>
+                      <FormControl>
+                        <MultipleSelector
+                          {...field}
+                          defaultOptions={TRANSPORTS}
+                          placeholder="Selecionar meios de transporte"
+                          hidePlaceholderWhenSelected={true}
+                          emptyIndicator={
+                            <p className="text-center text-lg leading-10 text-gray-600 dark:text-gray-400">
+                              Sem resultados
+                            </p>
+                          }
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="heardAboutENEI"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Como ouviste falar do ENEI?</FormLabel>
+                      <FormControl>
+                        <Select onValueChange={field.onChange} defaultValue={field.value}>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Seleciona uma opção" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {HEARD_ABOUT_FROM.map((source) => (
+                              <SelectItem key={source.value} value={source.value}>
+                                {source.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="reasonForSignup"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Qual a principal razão para te inscreveres no ENEI?</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          placeholder="Aprender novas tecnologias, melhorar soft skills..."
+                          className="resize-none"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <Button type="submit">Atualizar</Button>
+              </div>
+            </form>
+          </Form>
+        </Card>
       </Container>
     </Page>
   )

--- a/website/inertia/pages/profile/edit/page.tsx
+++ b/website/inertia/pages/profile/edit/page.tsx
@@ -50,14 +50,17 @@ import { format } from 'date-fns'
 import { pt } from 'date-fns/locale'
 import { cn } from '~/lib/utils'
 import { PhoneInput } from '~/components/ui/phone-input/phone-input'
-import { z } from 'zod'
 import CurricularYearSelector, { CurricularYearSelectorType } from '~/components/signup/input/curricular_year_input'
 import UniversitySelection from '~/components/signup/common/university_selection'
 import MultipleSelector, { Option } from '~/components/ui/multiple-selector'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
 import { Textarea } from '~/components/ui/textarea'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
-import { zodResolver } from '@hookform/resolvers/zod'
+import { useTuyau } from '~/hooks/use_tuyau'
+import { router, usePage } from '@inertiajs/react'
+import { PageProps } from '@adonisjs/inertia/types'
 import districts from '#data/enei/districts.json' with { type: 'json' }
 import sizes from '#data/enei/signup/shirts.json' with { type: 'json' }
 import heardaboutfrom from '#data/enei/signup/heard-about.json' with { type: 'json' }
@@ -113,7 +116,10 @@ function profileToCommonInfo(profile: ParticipantProfile & { heardAboutEnei?: st
 }
 
 export default function ProfilePage(props: InferPageProps<ProfilesController, 'index'> & { profile: ParticipantProfile }) {
+  const tuyau = useTuyau()
+
   const { profile }: { profile: ParticipantProfile } = props
+  const { csrfToken } = usePage<PageProps & { csrfToken: string; }>().props;
 
   const [initialValues, _] = useState<CommonInfo>(profileToCommonInfo(profile))
 
@@ -132,7 +138,10 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
       payload = { ...payload, [k]: data[k] }
     }
 
-    console.log("submit payload", payload)
+    router.patch(tuyau.$url('actions:profile.update'), {
+      ...payload,
+      _csrf: csrfToken
+    })
   }
 
   return (

--- a/website/inertia/pages/profile/edit/page.tsx
+++ b/website/inertia/pages/profile/edit/page.tsx
@@ -4,12 +4,19 @@ import ParticipantProfile from '#models/participant_profile'
 import { Button } from '~/components/ui/button'
 import Page from '~/components/common/page'
 import Container from '~/components/common/containers'
-import { getUniversityById } from '~/lib/enei/signup/universities'
-import { Badge } from '~/components/ui/badge'
 import { Card } from '~/components/ui/card'
-import { AdditionalInfo, additionalInfoSchema, CommunicationsInfo, communicationsInfoSchema, EducationInfo, educationInfoSchema, LogisticsInfo, logisticsInfoSchema, PersonalInfo, personalInfoSchema } from '~/pages/signup/schema'
-import { useForm } from 'react-hook-form'
-import { zodResolver } from '@hookform/resolvers/zod'
+import {
+  AdditionalInfo,
+  additionalInfoSchema,
+  CommunicationsInfo,
+  communicationsInfoSchema,
+  EducationInfo,
+  educationInfoSchema,
+  LogisticsInfo,
+  logisticsInfoSchema,
+  PersonalInfo,
+  personalInfoSchema,
+} from '~/pages/signup/schema'
 import {
   Form,
   FormControl,
@@ -28,12 +35,6 @@ import {
   CommandList,
 } from '~/components/ui/command'
 import {
-  Download,
-  User,
-  Github,
-  Linkedin,
-  Globe,
-  LucideProps,
   Eye,
   EyeOff,
   CalendarIcon,
@@ -52,32 +53,21 @@ import { PhoneInput } from '~/components/ui/phone-input/phone-input'
 import { z } from 'zod'
 import CurricularYearSelector, { CurricularYearSelectorType } from '~/components/signup/input/curricular_year_input'
 import UniversitySelection from '~/components/signup/common/university_selection'
+import MultipleSelector, { Option } from '~/components/ui/multiple-selector'
+import { Textarea } from '~/components/ui/textarea'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
 import districts from '#data/enei/districts.json' with { type: 'json' }
 import sizes from '#data/enei/signup/shirts.json' with { type: 'json' }
 import heardaboutfrom from '#data/enei/signup/heard-about.json' with { type: 'json' }
 import { universities } from '~/lib/enei/signup/universities'
 import { ENEI_EDITIONS } from '~/lib/enei/signup/editions'
-import MultipleSelector, { Option } from '~/components/ui/multiple-selector'
 import { TRANSPORTS } from '~/lib/enei/signup/transports'
-import { Textarea } from '~/components/ui/textarea'
-
-// TODO: Refactor exists in profile/page.tsx
-interface SocialIconProps {
-  icon: React.FC<LucideProps>;
-  link: string;
-}
 
 const INITIAL_MONTH = new Date(2004, 0, 1)
 const SIZES = sizes
 const HEARD_ABOUT_FROM: Option[] = heardaboutfrom
-
-const SocialIcon = ({ icon: Icon, link }: SocialIconProps) => {
-  return (
-    <a href={link} className='border-2 border-enei-blue rounded-full h-9 w-9 flex justify-center items-center' target="_blank" rel="noopener noreferrer">
-      <Icon className='h-5' />
-    </a>
-  )
-}
 
 type CommonInfo =
   & PersonalInfo
@@ -94,111 +84,61 @@ const commonSchema = z.object({
   ...additionalInfoSchema.shape,
 })
 
+// ISSUE: I don't really know why it is heardAboutEnei when it should be heardAboutENEI
+function profileToCommonInfo(profile: ParticipantProfile & { heardAboutEnei?: string }): CommonInfo {
+  return {
+    firstName: profile.firstName,
+    lastName: profile.lastName,
+    phone: profile.phone,
+    university: profile.university,
+    course: profile.course,
+    curricularYear: [profile.curricularYear as ("1" | "2" | "3" | "4" | "5" | "already-finished"), profile.finishedAt] as ["1" | "2" | "3" | "4" | "5", null] | ["already-finished", number],
+    shirtSize: profile.shirtSize,
+    dietaryRestrictions: profile.dietaryRestrictions ?? '',
+    isVegetarian: profile.isVegetarian ? true : false,
+    isVegan: profile.isVegan ? true : false,
+    transports: TRANSPORTS.filter((transport) => profile.transports.includes(transport.value)),
+    heardAboutENEI: profile.heardAboutEnei as string,
+    reasonForSignup: profile.reasonForSignup ?? '',
+    attendedBefore: profile.attendedBeforeEditions.length > 0,
+    attendedBeforeEditions: ENEI_EDITIONS.filter((edition) => profile.attendedBeforeEditions.includes(edition.value)),
+    about: profile.about ?? '',
+    github: profile.github ?? '',
+    linkedin: profile.linkedin ?? '',
+    website: profile.website ?? '',
+    dateOfBirth: new Date("2003-05-09"),
+    municipality: profile.municipality,
+    termsAndConditions: true,
+  }
+}
+
 export default function ProfilePage(props: InferPageProps<ProfilesController, 'index'> & { profile: ParticipantProfile }) {
-  const { profile } = props
+  const { profile }: { profile: ParticipantProfile } = props
 
-  const profileEditions = ENEI_EDITIONS.filter((edition) => profile.attendedBeforeEditions.includes(edition.value)).map((edition) => edition.label)
-
-  const socials: SocialIconProps[] = []
-
-  if (profile.github) socials.push({ icon: Github, link: profile.github })
-  if (profile.linkedin) socials.push({ icon: Linkedin, link: profile.linkedin })
-  if (profile.website) socials.push({ icon: Globe, link: profile.website })
+  const [initialValues, _] = useState<CommonInfo>(profileToCommonInfo(profile))
 
   const form = useForm<CommonInfo>({
     resolver: zodResolver(commonSchema),
-    defaultValues: {
-      firstName: '',
-      lastName: '',
-      phone: '',
-      university: '',
-      course: '',
-      curricularYear: ['1', null] as CurricularYearSelectorType,
-      shirtSize: '',
-      dietaryRestrictions: '',
-      isVegetarian: false,
-      isVegan: false,
-      transports: [],
-      heardAboutENEI: '',
-      reasonForSignup: '',
-      attendedBefore: false,
-      attendedBeforeEditions: [],
-      termsAndConditions: false,
-      about: '',
-      github: '',
-      linkedin: '',
-      website: '',
-    },
+    defaultValues: initialValues,
   })
 
   const onSubmit = (data: CommonInfo) => {
-    console.log(data)
+    let payload: Partial<CommonInfo> = {}
+
+    for (const [key, value] of Object.entries(form.formState.dirtyFields)) {
+      if (!value) continue
+      const k: keyof CommonInfo = key as keyof CommonInfo
+
+      payload = { ...payload, [k]: data[k] }
+    }
+
+    console.log("submit payload", payload)
   }
 
   return (
     <Page title={`${profile.firstName} ${profile.lastName}`} className="bg-enei-beige text-enei-blue">
       <Container className='mt-8'>
         <Card className='p-4'>
-          <section className="relative flex flex-col gap-8 md:justify-between z-10">
-            <h3 className='text-2xl'>Perfil do Participante</h3>
-
-            <section className='grid md:grid-cols-[auto_1fr] items-center gap-4 md:gap-8'>
-              <div className='size-fit rounded-sm bg-enei-blue mx-auto md:mx-0'>
-                <User className='w-48 h-48 text-enei-beige' />
-              </div>
-              <div className='h-full flex flex-col gap-2 justify-between text-center md:text-start'>
-                <p className='text-3xl'>
-                  {profile.firstName} {profile.lastName}
-                </p>
-                <div>
-                  <p className='text-lg'> {profile.course} &#183; {(profile.curricularYear === 'already-finished') ? ("Concluído em " + profile.finishedAt) : (profile.curricularYear + "º ano")} </p>
-                  <p className='text-lg'> @ {getUniversityById(profile.university)!.name} </p>
-                </div>
-                <div className='flex flex-row flex-wrap gap-2 justify-center md:justify-start'>
-                  {socials.length > 0 &&
-                    socials.map((social: SocialIconProps) => (
-                      <SocialIcon {...social} />
-                    ))
-                  }
-                  <div className='flex flex-row gap-2'>
-                    <Button className='w-fit'>
-                      <Download />
-                      Currículo
-                    </Button>
-                  </div>
-                </div>
-                {profileEditions.length > 0 ?
-                  <div className='flex flex-row flex-wrap gap-2 justify-center md:justify-normal'>
-                    {profileEditions.map((edition) => (
-                      <Badge>
-                        {edition}
-                      </Badge>
-                    ))}
-                  </div>
-                  :
-                  <div>
-                    <Badge variant={'default'}>
-                      Primeiro ENEI
-                    </Badge>
-                  </div>
-                }
-              </div>
-            </section>
-            <section className='grid grid-rows-[auto_1fr] gap-4 mt-4'>
-              <div>
-                <h4 className='font-bold text-lg text-center md:text-left'>
-                  Sobre
-                </h4>
-                <p>
-                  {profile.about ?? "Sem informação."}
-                </p>
-              </div>
-            </section>
-          </section>
-
-
-
-
           <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)}>
               <div className="flex flex-col gap-4">
@@ -385,7 +325,7 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
                     <FormItem className="flex-1">
                       <FormLabel>URL do teu GitHub</FormLabel>
                       <FormControl>
-                        <Input placeholder="NIAEFEUP" type="text" {...field} />
+                        <Input placeholder="https://github.com/NIAEFEUP" type="text" {...field} />
                       </FormControl>
                       <FormMessage />
                     </FormItem>
@@ -398,7 +338,7 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
                     <FormItem className="flex-1">
                       <FormLabel>URL do teu Linkedin</FormLabel>
                       <FormControl>
-                        <Input placeholder="NIAEFEUP" type="text" {...field} />
+                        <Input placeholder="https://www.linkedin.com/in/oteunome" type="text" {...field} />
                       </FormControl>
                       <FormMessage />
                     </FormItem>
@@ -411,17 +351,19 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
                     <FormItem className="flex-1">
                       <FormLabel>URL do teu Website Pessoal</FormLabel>
                       <FormControl>
-                        <Input placeholder="ni.fe.up.pt" type="text" {...field} />
+                        <Input placeholder="https://ni.fe.up.pt" type="text" {...field} />
                       </FormControl>
                       <FormMessage />
                     </FormItem>
                   )}
                 />
                 { /* TODO: */}
-                <br />
-                foto de perfil: // todo
-                <br />
-                Currículo: // TODO
+                <div className='hidden'>
+                  <br />
+                  foto de perfil: // TODO
+                  <br />
+                  Currículo: // TODO
+                </div>
 
                 <div className='grid grid-cols-[auto_1fr] gap-2 items-center my-2'>
                   <EyeOff />
@@ -653,7 +595,7 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
                   )}
                 />
 
-                <Button type="submit">Atualizar</Button>
+                <Button type="submit" disabled={!form.formState.isDirty}>Atualizar</Button>
               </div>
             </form>
           </Form>

--- a/website/inertia/pages/profile/page.tsx
+++ b/website/inertia/pages/profile/page.tsx
@@ -40,9 +40,9 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
 
   const socials: SocialIconProps[] = []
 
-  if (profile.github) socials.push({ icon: Github, link: `https://github.com/${profile.github}` })
-  if (profile.linkedin) socials.push({ icon: Linkedin, link: `https://linkedin.com/in/${profile.linkedin}` })
-  if (profile.website) socials.push({ icon: Globe, link: `//${profile.website}` })
+  if (profile.github) socials.push({ icon: Github, link: profile.github })
+  if (profile.linkedin) socials.push({ icon: Linkedin, link: profile.linkedin })
+  if (profile.website) socials.push({ icon: Globe, link: profile.website })
 
   return (
     <Page title={`${profile.firstName} ${profile.lastName}`} className="bg-enei-beige text-enei-blue">

--- a/website/inertia/pages/profile/page.tsx
+++ b/website/inertia/pages/profile/page.tsx
@@ -5,7 +5,7 @@ import { Button, buttonVariants } from '~/components/ui/button'
 import Page from '~/components/common/page'
 import Container from '~/components/common/containers'
 import { getUniversityById } from '~/lib/enei/signup/universities'
-import { Download, User, Github, Linkedin, Globe, QrCode, LucideProps, Pencil} from 'lucide-react'
+import { Download, User, Github, Linkedin, Globe, QrCode, LucideProps, Pencil } from 'lucide-react'
 import { Dialog, DialogContent, DialogTrigger } from '~/components/ui/dialog'
 import { QRCodeSVG } from 'qrcode.react';
 import { useEffect, useState } from 'react'
@@ -31,7 +31,7 @@ const ENEI_EDITIONS: Option[] = editions
 
 const SocialIcon = ({ icon: Icon, link }: SocialIconProps) => {
   return (
-    <a href={link} className='border-2 border-enei-blue rounded-full h-9 w-9 flex justify-center items-center'>
+    <a href={link} className='border-2 border-enei-blue rounded-full h-9 w-9 flex justify-center items-center' target="_blank" rel="noopener noreferrer">
       <Icon className='h-5' />
     </a>
   )
@@ -52,11 +52,11 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
 
   if (profile.github) socials.push({ icon: Github, link: `https://github.com/${profile.github}` })
   if (profile.linkedin) socials.push({ icon: Linkedin, link: `https://linkedin.com/in/${profile.linkedin}` })
-  if (profile.website) socials.push({ icon: Globe, link: profile.website })
+  if (profile.website) socials.push({ icon: Globe, link: `//${profile.website}` })
 
   return (
     <Page title={`${profile.firstName} ${profile.lastName}`} className="bg-enei-beige text-enei-blue">
-      <Container>
+      <Container className='mt-8'>
         <section className="relative flex flex-col gap-8 md:justify-between z-10">
           <div className='flex flex-row justify-normal gap-4'>
             <h3 className='text-2xl'>Perfil do Participante</h3>

--- a/website/inertia/pages/profile/page.tsx
+++ b/website/inertia/pages/profile/page.tsx
@@ -12,22 +12,12 @@ import { useEffect, useState } from 'react'
 import { Link } from '@tuyau/inertia/react'
 import { cn } from '~/lib/utils'
 import { Badge } from '~/components/ui/badge'
-import editions from '#data/enei/editions.json' with { type: 'json' }
-import { Option } from '~/components/ui/multiple-selector'
+import { ENEI_EDITIONS } from '~/lib/enei/signup/editions'
 
 interface SocialIconProps {
   icon: React.FC<LucideProps>;
   link: string;
 }
-
-const ENEI_EDITIONS: Option[] = editions
-  .sort((a, b) => b.year - a.year)
-  .map(({ year, location }) => {
-    return {
-      label: location + ', ' + year.toString(),
-      value: year.toString(),
-    }
-  })
 
 const SocialIcon = ({ icon: Icon, link }: SocialIconProps) => {
   return (

--- a/website/inertia/pages/profile/page.tsx
+++ b/website/inertia/pages/profile/page.tsx
@@ -79,10 +79,10 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
                   <p className='text-lg'> @ {getUniversityById(profile.university)!.name} </p>
                 </div>
               }
-              {profile.jobTitle && profile.speakerRole &&
+              {profile.jobTitle && profile.company &&
                 <div>
                   <p className='text-lg'> &#183; {profile.jobTitle} &#183; </p>
-                  <p className='text-lg'> @{profile.speakerRole} </p>
+                  <p className='text-lg'> @ {profile.company.name} </p>
                 </div>
               }
               <div className='flex flex-row flex-wrap gap-2 justify-center md:justify-start'>

--- a/website/inertia/pages/profile/page.tsx
+++ b/website/inertia/pages/profile/page.tsx
@@ -1,6 +1,5 @@
 import { InferPageProps } from '@adonisjs/inertia/types'
 import ProfilesController from '#controllers/profiles_controller'
-import ParticipantProfile from '#models/participant_profile'
 import { Button, buttonVariants } from '~/components/ui/button'
 import Page from '~/components/common/page'
 import Container from '~/components/common/containers'
@@ -27,7 +26,7 @@ const SocialIcon = ({ icon: Icon, link }: SocialIconProps) => {
   )
 }
 
-export default function ProfilePage(props: InferPageProps<ProfilesController, 'index'> & { profile: ParticipantProfile }) {
+export default function ProfilePage(props: InferPageProps<ProfilesController, 'index'>) {
   const { profile, isUser } = props
 
   const [windowHref, setWindowHref] = useState("");
@@ -35,7 +34,7 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
   useEffect(() => {
     setWindowHref(window.location.href)
   })
-
+  
   const profileEditions = ENEI_EDITIONS.filter((edition) => profile.attendedBeforeEditions.includes(edition.value)).map((edition) => edition.label)
 
   const socials: SocialIconProps[] = []

--- a/website/inertia/pages/profile/page.tsx
+++ b/website/inertia/pages/profile/page.tsx
@@ -12,6 +12,7 @@ import { Link } from '@tuyau/inertia/react'
 import { cn } from '~/lib/utils'
 import { Badge } from '~/components/ui/badge'
 import { ENEI_EDITIONS } from '~/lib/enei/signup/editions'
+import { Avatar, AvatarImage } from '~/components/ui/avatar'
 
 interface SocialIconProps {
   icon: React.FC<LucideProps>;
@@ -34,8 +35,10 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
   useEffect(() => {
     setWindowHref(window.location.href)
   })
-  
-  const profileEditions = ENEI_EDITIONS.filter((edition) => profile.attendedBeforeEditions.includes(edition.value)).map((edition) => edition.label)
+
+  const profileEditions = profile.attendedBeforeEditions
+    ? ENEI_EDITIONS.filter((edition) => profile.attendedBeforeEditions.includes(edition.value)).map((edition) => edition.label)
+    : undefined
 
   const socials: SocialIconProps[] = []
 
@@ -44,11 +47,11 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
   if (profile.website) socials.push({ icon: Globe, link: profile.website })
 
   return (
-    <Page title={`${profile.firstName} ${profile.lastName}`} className="bg-enei-beige text-enei-blue">
+    <Page title={`${profile.firstName} ${profile.lastName}`} className="bg-enei-beige text-enei-blue" >
       <Container className='mt-8'>
         <section className="relative flex flex-col gap-8 md:justify-between z-10">
           <div className='flex flex-row justify-normal gap-4'>
-            <h3 className='text-2xl'>Perfil do Participante</h3>
+            <h3 className='text-2xl'>Perfil do Utilizador</h3>
             {isUser &&
               <Link route="pages:profile.edit" className={cn(buttonVariants({ variant: 'default' }), 'w-fit')}>
                 <Pencil />
@@ -59,16 +62,29 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
 
           <section className='grid md:grid-cols-[auto_1fr] items-center gap-4 md:gap-8'>
             <div className='size-fit rounded-sm bg-enei-blue mx-auto md:mx-0'>
-              <User className='w-48 h-48 text-enei-beige' />
+              {profile.logo
+                ?
+                <Avatar className='w-48 h-48 text-enei-beige'>
+                  <AvatarImage src={profile.logo} />
+                </Avatar>
+                : <User className='w-48 h-48 text-enei-beige' />}
             </div>
             <div className='h-full flex flex-col gap-2 justify-between text-center md:text-start'>
               <p className='text-3xl'>
-                {profile.firstName} {profile.lastName}
+                {profile.name ? profile.name : profile.firstName + " " + profile.lastName}
               </p>
-              <div>
-                <p className='text-lg'> {profile.course} &#183; {(profile.curricularYear === 'already-finished') ? ("Concluído em " + profile.finishedAt) : (profile.curricularYear + "º ano")} </p>
-                <p className='text-lg'> @ {getUniversityById(profile.university)!.name} </p>
-              </div>
+              {profile.course &&
+                <div>
+                  <p className='text-lg'> {profile.course} &#183; {(profile.curricularYear === 'already-finished') ? ("Concluído em " + profile.finishedAt) : (profile.curricularYear + "º ano")} </p>
+                  <p className='text-lg'> @ {getUniversityById(profile.university)!.name} </p>
+                </div>
+              }
+              {profile.jobTitle && profile.speakerRole &&
+                <div>
+                  <p className='text-lg'> &#183; {profile.jobTitle} &#183; </p>
+                  <p className='text-lg'> @{profile.speakerRole} </p>
+                </div>
+              }
               <div className='flex flex-row flex-wrap gap-2 justify-center md:justify-start'>
                 {socials.length > 0 &&
                   socials.map((social: SocialIconProps) => (
@@ -76,15 +92,25 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
                   ))
                 }
                 <div className='flex flex-row gap-2'>
-                  <Button className='w-fit'>
-                    <Download />
-                    Currículo
-                  </Button>
+                  {profile.orcidLink ?
+                    <a href={profile.orcidLink} target="_blank" rel="noopener noreferrer">
+                      <Button className='w-fit'>
+                        <Globe />
+                        ORCID Link
+                      </Button>
+                    </a>
+                    : (!profile.name &&
+                      <Button className='w-fit'>
+                        <Download />
+                        Currículo
+                      </Button>
+                    )
+                  }
                   <Dialog>
                     <DialogTrigger asChild>
                       <Button className='w-fit'>
                         <QrCode />
-                        Código QR
+                        Código QR
                       </Button>
                     </DialogTrigger>
                     <DialogContent className="w-4/5 max-w-96 sm:w-96 pt-12">
@@ -94,7 +120,7 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
                   </Dialog>
                 </div>
               </div>
-              {profileEditions.length > 0 ?
+              {profileEditions !== undefined ? (profileEditions.length > 0 ?
                 <div className='flex flex-row flex-wrap gap-2 justify-center md:justify-normal'>
                   {profileEditions.map((edition) => (
                     <Badge>
@@ -108,6 +134,17 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
                     Primeiro ENEI
                   </Badge>
                 </div>
+              ) :
+                <div>
+                  <Badge variant={'default'}>
+                    {profile.name ? "Company" :
+                      profile.speakerRole === "keynote_speaker" ? "Keynote Speaker" :
+                        profile.speakerRole === "panelist" ? "Panelist" :
+                          profile.speakerRole === "moderator" ? "Moderator" :
+                            "Speaker"
+                    }
+                  </Badge>
+                </div>
               }
             </div>
           </section>
@@ -117,12 +154,12 @@ export default function ProfilePage(props: InferPageProps<ProfilesController, 'i
                 Sobre
               </h4>
               <p>
-                {profile.about ?? "Sem informação."}
+                {profile.about ?? "Sem informação."}
               </p>
             </div>
           </section>
         </section>
       </Container>
-    </Page>
+    </Page >
   )
 }

--- a/website/inertia/pages/signup/schema.ts
+++ b/website/inertia/pages/signup/schema.ts
@@ -95,7 +95,7 @@ export const communicationsInfoSchema = z.object({
 export type AdditionalInfo = z.output<typeof additionalInfoSchema>
 export const additionalInfoSchema = z.object({
   about: z.string().optional(),
-  github: z.string().url({message: 'URL inválida'}).optional(),
-  linkedin: z.string().url({message: 'URL inválida'}).optional(),
-  website: z.string().url({message: 'URL inválida'}).optional(),
+  github: z.union([z.literal(''), z.string().url({ message: 'URL inválida' })]),
+  linkedin: z.union([z.literal(''), z.string().url({ message: 'URL inválida' })]),
+  website: z.union([z.literal(''), z.string().url({ message: 'URL inválida' })]),
 })

--- a/website/inertia/pages/signup/schema.ts
+++ b/website/inertia/pages/signup/schema.ts
@@ -91,3 +91,11 @@ export const communicationsInfoSchema = z.object({
     .optional(),
   termsAndConditions,
 })
+
+export type AdditionalInfo = z.output<typeof additionalInfoSchema>
+export const additionalInfoSchema = z.object({
+  about: z.string().optional(),
+  github: z.string().url({message: 'URL inválida'}).optional(),
+  linkedin: z.string().url({message: 'URL inválida'}).optional(),
+  website: z.string().url({message: 'URL inválida'}).optional(),
+})

--- a/website/start/routes.ts
+++ b/website/start/routes.ts
@@ -167,6 +167,9 @@ router
     router.get("/profile/edit", [ProfilesController, 'edit'])
       .as('pages:profile.edit')
       .use([middleware.auth(), middleware.verifiedEmail()])
+    router.patch("/profile/edit", [ProfilesController, 'update'])
+      .as('actions:profile.update')
+      .use([middleware.auth(), middleware.verifiedEmail()])
   })
 
 router
@@ -200,7 +203,6 @@ router.
     })
   })
   .use([middleware.auth()])
-  
   .prefix('user')
 
 
@@ -212,13 +214,13 @@ router
   })
   .use([middleware.auth(), middleware.verifiedEmail(), /*middleware.participant()*/])
   .prefix('/store')
-  
+
 // Referrals
 router.get('/referrals', [ReferralsController, 'showReferralLink'])
   .middleware(middleware.auth())
   .as('pages:referrals')
 
 router.route(`/r/:referralCode`, ['GET', 'POST'], [ReferralsController, 'link'])
-  .middleware([middleware.automaticSubmit(), middleware.silentAuth()]) 
+  .middleware([middleware.automaticSubmit(), middleware.silentAuth()])
   .as('actions:referrals.link')
 


### PR DESCRIPTION
## PR

This PR adds the capability for Companies and Speakers to have profiles of their own, using the base design of the Participant Profiles already included, with dynamic field loading according to type.

| ![image](https://github.com/user-attachments/assets/b4988c42-9d4b-411a-b55d-42c230261cee) |
|:--:|
| *Participant* |
| ![image](https://github.com/user-attachments/assets/dec08360-3d4a-4e8e-9567-b5adf22e7cc1) |
| *Speaker* |
| ![image](https://github.com/user-attachments/assets/0ebd2b30-69e2-4430-bb30-52d646e55dc8) |
| *Company* |

## Note

I made this PR to have a little bit of feedback according the **design choices** (especially on the company one) aswell as to **check if the info on the database for each type of Profile is enough** or if I should add more info.

Also, can the companies and speakers edit their profiles or is that done through the Admin area when it is replaced/fixed??