### PR TITLE
Fix footer position on large monitors

### DIFF
--- a/apps/website/inertia/components/common/page.tsx
+++ b/apps/website/inertia/components/common/page.tsx
@@ -40,7 +40,7 @@ export default function Page({
       )}
     >
       <Head title={title} />
-      <div className="relative pb-48">
+      <div className="relative flex-grow pb-48">
         <Navbar className="sticky top-0 z-20 grow-0" variant={variant} />
         <PromoterNotification />
         <div className={className}>{children}</div>


### PR DESCRIPTION
The footer was misaligned on large monitors, this PR simply grows the container for the main content so the footer is always at the bottom of the page.

Before: ![image](https://github.com/user-attachments/assets/7bf52d90-a568-425f-a648-8f519b27bd56)

After: ![image](https://github.com/user-attachments/assets/85fa1fef-d6a2-4609-b83a-1b510ea8e883)
