### PR TITLE
Rename credential scanning route and add slug to drawer

### DIFF
--- a/apps/website/inertia/components/common/navbar.tsx
+++ b/apps/website/inertia/components/common/navbar.tsx
@@ -110,7 +110,7 @@ export function Navbar({ className, variant }: { className?: string; variant?: "
                 }
               >
                 <Link
-                  route="pages:staff.qrcode.scan"
+                  route="pages:staff.credentials.scan"
                   className={cn(buttonVariants({ variant: "link" }), `text-${textColor}`)}
                 >
                   <QrCode />

--- a/apps/website/inertia/components/credentials/writer.tsx
+++ b/apps/website/inertia/components/credentials/writer.tsx
@@ -1,0 +1,28 @@
+import { useTuyau } from "~/hooks/use_tuyau";
+import NFC from "./nfc";
+
+interface CredentialWriterProps {
+  slug: string;
+}
+
+function CredentialWriter({ slug }: CredentialWriterProps) {
+  const tuyau = useTuyau();
+
+  return (
+    <NFC
+      makeReadOnly
+      writeValue={{
+        records: [
+          {
+            recordType: "url",
+            data: tuyau.$url("pages:profile.show", {
+              params: { slug },
+            }),
+          },
+        ],
+      }}
+    />
+  );
+}
+
+export default CredentialWriter;

--- a/apps/website/inertia/components/profile/profile_info_drawer.tsx
+++ b/apps/website/inertia/components/profile/profile_info_drawer.tsx
@@ -2,9 +2,7 @@ import ParticipantProfile from "#models/participant_profile";
 import { Link } from "@tuyau/inertia/react";
 import { User } from "lucide-react";
 import { Drawer, DrawerContent } from "~/components/ui/drawer";
-import { Button } from "~/components/ui/button";
-import NFC from "../credentials/nfc";
-import { useTuyau } from "~/hooks/use_tuyau";
+import CredentialWriter from "../credentials/writer";
 
 interface ProfileInfoDrawerProps {
   profile: ParticipantProfile;
@@ -12,8 +10,6 @@ interface ProfileInfoDrawerProps {
 }
 
 function ProfileInfoDrawer({ profile, onClose }: ProfileInfoDrawerProps) {
-  const tuyau = useTuyau();
-
   return (
     <Drawer
       defaultOpen={true}
@@ -26,36 +22,26 @@ function ProfileInfoDrawer({ profile, onClose }: ProfileInfoDrawerProps) {
       }}
     >
       <DrawerContent className="bg-enei-beige text-enei-blue absolute gap-4 p-4">
-        <div className="mx-auto flex w-1/4 flex-row items-center justify-between">
-          <User className="h-48 w-48"></User>
-          <div className="flex flex-col gap-1">
-            <Button asChild>
-              <Link
-                route="pages:profile.show"
-                params={{ slug: profile.slug ?? "" }}
-                target="_blank"
-              >
-                <p>Ir para o perfil</p>
-              </Link>
-            </Button>
-            <p className="">{`${profile.firstName} ${profile.lastName}`}</p>
-            <p className="">{`${profile.university} | ${profile.course}`}</p>
+        <div className="mx-auto flex w-full max-w-96 flex-col items-center gap-2">
+          <div className="relative flex flex-row items-center">
+            <User className="size-16" />
+            <div className="flex flex-col">
+              <p>
+                <Link
+                  className="after:absolute after:inset-0 hover:underline"
+                  route="pages:profile.show"
+                  params={{ slug: profile.slug ?? "" }}
+                  target="_blank"
+                >
+                  {profile.firstName} {profile.lastName}
+                </Link>
+              </p>
+              <p>{profile.slug}</p>
+            </div>
           </div>
-        </div>
 
-        <NFC
-          makeReadOnly
-          writeValue={{
-            records: [
-              {
-                recordType: "url",
-                data: tuyau.$url("pages:profile.show", {
-                  params: { slug: profile.slug ?? "" },
-                }),
-              },
-            ],
-          }}
-        />
+          <CredentialWriter slug={profile.slug ?? ""} />
+        </div>
       </DrawerContent>
     </Drawer>
   );

--- a/apps/website/inertia/pages/credentials/page.tsx
+++ b/apps/website/inertia/pages/credentials/page.tsx
@@ -2,21 +2,21 @@ import axios from "axios";
 import { useState } from "react";
 import Container from "~/components/common/containers";
 import Page from "~/components/common/page";
-import CredentialScanner from "~/components/credentials/scanner";
+import Scanner from "~/components/credentials/scanner";
 import ProfileInfoDrawer from "~/components/profile/profile_info_drawer";
 import { useTuyau } from "~/hooks/use_tuyau";
 
-export default function QrScanner() {
+export default function CredentialScanner() {
   const tuyau = useTuyau();
 
   const [profile, setProfile] = useState<any>(null);
 
   return (
-    <Page title="QRCode Scanner" className="bg-enei-beige text-enei-blue" variant="beige">
+    <Page title="Scan de Credenciais" className="bg-enei-beige text-enei-blue" variant="beige">
       <Container className="max-w-xl">
         <div className="mx-auto flex w-3/4 flex-col gap-y-4">
-          <h3 className="text-center text-lg font-bold">Dá scan ao qrcode</h3>
-          <CredentialScanner
+          <h3 className="text-center text-lg font-bold">Dá scan à credencial</h3>
+          <Scanner
             onScan={(slug: string) => {
               axios.get(tuyau.$url("actions:profile.info", { params: { slug } })).then((res) => {
                 setProfile(res.data.profile);

--- a/apps/website/start/routes.ts
+++ b/apps/website/start/routes.ts
@@ -280,9 +280,9 @@ router
 
 router
   .group(() => {
-    router.on("/scan").renderInertia("qrscanner").as("pages:staff.qrcode.scan");
+    router.on("/scan").renderInertia("credentials").as("pages:staff.credentials.scan");
   })
   .use([middleware.auth(), middleware.staff()])
-  .prefix("/qrcode");
+  .prefix("/credentials");
 
 router.on("/nfc").renderInertia("nfc").as("pages:nfc");


### PR DESCRIPTION
Renames `/qrcode/scan` to `/credentials/scan` and adds the user slug to the drawer.

![image](https://github.com/user-attachments/assets/8f18af4c-0e81-4991-b78f-ff87511e443a)
